### PR TITLE
fix(gen_stub): use toVarEscapedName for union type ZEND_TYPE_INIT_CLASS

### DIFF
--- a/src/gen_stub.php
+++ b/src/gen_stub.php
@@ -2881,8 +2881,8 @@ abstract class VariableLike
                     $code .= "\t{$variableLikeType}_{$variableLikeName}_type_list->num_types = $classTypeCount;\n";
 
                     foreach ($arginfoType->classTypes as $k => $classType) {
-                        $escapedClassName = $classType->toEscapedName();
-                        $code .= "\t{$variableLikeType}_{$variableLikeName}_type_list->types[$k] = (zend_type) ZEND_TYPE_INIT_CLASS({$variableLikeType}_{$variableLikeName}_class_{$escapedClassName}, 0, 0);\n";
+                        $varEscapedClassName = $classType->toVarEscapedName();
+                        $code .= "\t{$variableLikeType}_{$variableLikeName}_type_list->types[$k] = (zend_type) ZEND_TYPE_INIT_CLASS({$variableLikeType}_{$variableLikeName}_class_{$varEscapedClassName}, 0, 0);\n";
                     }
 
                     $typeMaskCode = $this->type->toArginfoType()->toTypeMask();


### PR DESCRIPTION
Fixes C++ compilation failure when generating arginfo for union/intersection types with 2+ namespaced class types.

## Bug

`gen_stub.php:2885` used `toEscapedName()` which preserves PHP `\` namespace separators, producing invalid C++ identifiers like `App\\\Model\\\Raw`. This causes:

```
error: stray '\' in program
```

## Fix

Use `toVarEscapedName()` (replaces `\` with `_`), consistent with the single-class-type branch at line 2901.

```diff
- $escapedClassName = $classType->toEscapedName();
+ $varEscapedClassName = $classType->toVarEscapedName();
```

## Reproduction

Any namespaced class with a union-typed property containing 2+ class types:

```php
namespace App\Model;

class WhereCondition
{
    protected Raw|Closure $value;  // triggers the bug
}
```

Generated arginfo before fix:
```cpp
ZEND_TYPE_INIT_CLASS(property_value_class_App\\Model\\Raw, 0, 0)  // invalid
```

After fix:
```cpp
ZEND_TYPE_INIT_CLASS(property_value_class_App_Model_Raw, 0, 0)   // correct
```