### PR TITLE
fix(attribute): mark ClassConstFetch as lazy to resolve enum attribute args

### DIFF
--- a/src/Transform/RuntimeAttributeFactoryLowering.php
+++ b/src/Transform/RuntimeAttributeFactoryLowering.php
@@ -131,6 +131,7 @@ final class RuntimeAttributeFactoryLowering extends NodeVisitorAbstract
                 // though it is not represented by an Array_ AST node.
                 || $node instanceof Expr\Cast\Array_
                 || $node instanceof Expr\Cast\Object_
+                || $node instanceof Expr\ClassConstFetch
                 || (($node instanceof Expr\FuncCall || $node instanceof Expr\StaticCall)
                     && $node->isFirstClassCallable());
         }) !== null;

--- a/src/Transform/RuntimeAttributeFactoryLowering.php
+++ b/src/Transform/RuntimeAttributeFactoryLowering.php
@@ -124,6 +124,10 @@ final class RuntimeAttributeFactoryLowering extends NodeVisitorAbstract
             return true;
         }
 
+        if ($value instanceof Expr\ClassConstFetch) {
+            return true;
+        }
+
         return (new NodeFinder())->findFirst($value, static function (Node $node): bool {
             return $node instanceof Expr\New_
                 || $node instanceof Expr\Closure
@@ -131,7 +135,6 @@ final class RuntimeAttributeFactoryLowering extends NodeVisitorAbstract
                 // though it is not represented by an Array_ AST node.
                 || $node instanceof Expr\Cast\Array_
                 || $node instanceof Expr\Cast\Object_
-                || $node instanceof Expr\ClassConstFetch
                 || (($node instanceof Expr\FuncCall || $node instanceof Expr\StaticCall)
                     && $node->isFirstClassCallable());
         }) !== null;


### PR DESCRIPTION
## Bug

When a backed enum value is used as an attribute argument (e.g. `#[TableId(IdType::AUTO)]`), the compiled binary stores the string backing value instead of the enum instance.

**Reproduction:**
```php
enum Status: string { case Active = 'active'; }

#[Attribute(Attribute::TARGET_CLASS)]
class ValidateStatus {
    public function __construct(public Status $status = Status::Active) {}
}

#[ValidateStatus(Status::Active)]
class User {}
- PHP mode: ✅ $status is Status enum instance
- Compiled mode: ❌ $status is string "active", throws TypeError
Root Cause
RuntimeAttributeFactoryLowering::requiresLazyValue() did not recognize ClassConstFetch nodes. A factory function was generated (via requiresFactory()), but without the lazy marker the PHPX bridge never invoked it — the arginfo stored the raw string instead of calling php::getEnumCase().
Fix
Add Expr\ClassConstFetch to requiresLazyValue() so the lazy marker is set and the factory is invoked at runtime.
Before: ZVAL_INTERNED_STR(..., "active")
After: typephp_attribute_set_lazy_value_argument(..., factory) → php::getEnumCase("Status", "Active")