### PR TITLE
Fix dynamic strict flag in optimized array_keys calls

### DIFF
--- a/src/Optimizer/FuncCallOptimizer.php
+++ b/src/Optimizer/FuncCallOptimizer.php
@@ -766,10 +766,13 @@ trait FuncCallOptimizer
         return 'php::fn::get_parent_class(' . $this->parseIdentifier($arg) . ')';
     }
 
-    protected function genArrayKeys(string $n, Node\Expr\FuncCall $e, array $c): string
+    protected function genArrayKeys(string $n, Node\Expr\FuncCall $e, array $c): string|false
     {
         $cnt = count($e->args);
         if ($cnt >= 3) {
+            if ($this->detectTypeOfExpr($e->args[2]->value) !== Type::BOOL) {
+                return false;
+            }
             return 'php::fn::array_keys_filter(' . $this->getArg($e, 0) . ', ' . $this->getArg($e, 1) . ', '
                 . $this->resolveArg($e, 2, self::ARG_TYPE_BOOL) . ')';
         }

--- a/src/Optimizer/FuncCallOptimizer.php
+++ b/src/Optimizer/FuncCallOptimizer.php
@@ -770,7 +770,8 @@ trait FuncCallOptimizer
     {
         $cnt = count($e->args);
         if ($cnt >= 3) {
-            return 'php::fn::array_keys_filter(' . $this->getArg($e, 0) . ', ' . $this->getArg($e, 1) . ', ' . $this->getArg($e, 2) . ')';
+            return 'php::fn::array_keys_filter(' . $this->getArg($e, 0) . ', ' . $this->getArg($e, 1) . ', '
+                . $this->resolveArg($e, 2, self::ARG_TYPE_BOOL) . ')';
         }
         if ($cnt >= 2) {
             return 'php::fn::array_keys_filter(' . $this->getArg($e, 0) . ', ' . $this->getArg($e, 1) . ', false)';

--- a/tests/compiler/stdlib/array-keys-dynamic-arguments.phpt
+++ b/tests/compiler/stdlib/array-keys-dynamic-arguments.phpt
@@ -1,0 +1,89 @@
+--TEST--
+array_keys optimized calls convert dynamic arguments and preserve evaluation order
+--FILE--
+<?php
+declare(strict_types=1);
+
+final class ArrayKeysOptions
+{
+    public bool $strict = true;
+}
+
+function arrayKeysDynamicStrict(array &$events): bool
+{
+    $events[] = 'strict';
+    return true;
+}
+
+function arrayKeysDynamicValues(array &$events): array
+{
+    $events[] = 'array';
+    return ['integer' => 1, 'string' => '1'];
+}
+
+function arrayKeysDynamicFilter(array &$events): mixed
+{
+    $events[] = 'filter';
+    return '1';
+}
+
+function main()
+{
+    $values = ['integer' => 1, 'string' => '1'];
+
+    var_dump(array_keys($values));
+    var_dump(array_keys($values, '1'));
+    var_dump(array_keys($values, '1', true));
+
+    $strict = true;
+    var_dump(array_keys($values, '1', $strict));
+
+    $options = new ArrayKeysOptions();
+    var_dump(array_keys($values, '1', $options->strict));
+
+    $events = [];
+    var_dump(array_keys(
+        arrayKeysDynamicValues($events),
+        arrayKeysDynamicFilter($events),
+        arrayKeysDynamicStrict($events)
+    ));
+    var_dump($events);
+}
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(7) "integer"
+  [1]=>
+  string(6) "string"
+}
+array(2) {
+  [0]=>
+  string(7) "integer"
+  [1]=>
+  string(6) "string"
+}
+array(1) {
+  [0]=>
+  string(6) "string"
+}
+array(1) {
+  [0]=>
+  string(6) "string"
+}
+array(1) {
+  [0]=>
+  string(6) "string"
+}
+array(1) {
+  [0]=>
+  string(6) "string"
+}
+array(3) {
+  [0]=>
+  string(5) "array"
+  [1]=>
+  string(6) "filter"
+  [2]=>
+  string(6) "strict"
+}

--- a/tests/compiler/stdlib/array-keys-dynamic-arguments.phpt
+++ b/tests/compiler/stdlib/array-keys-dynamic-arguments.phpt
@@ -1,5 +1,5 @@
 --TEST--
-array_keys optimized calls convert dynamic arguments and preserve evaluation order
+array_keys optimized calls preserve dynamic arguments, strict types, and evaluation order
 --FILE--
 <?php
 declare(strict_types=1);
@@ -27,6 +27,26 @@ function arrayKeysDynamicFilter(array &$events): mixed
     return '1';
 }
 
+function arrayKeysMixedBool(): mixed
+{
+    return true;
+}
+
+function arrayKeysMixedInt(): mixed
+{
+    return 1;
+}
+
+function arrayKeysMixedArray(): mixed
+{
+    return [];
+}
+
+function arrayKeysUnionInt(): bool|int
+{
+    return 1;
+}
+
 function main()
 {
     $values = ['integer' => 1, 'string' => '1'];
@@ -48,6 +68,29 @@ function main()
         arrayKeysDynamicStrict($events)
     ));
     var_dump($events);
+
+    var_dump(array_keys($values, '1', arrayKeysMixedBool()));
+
+    try {
+        array_keys($values, '1', arrayKeysMixedInt());
+        echo "mixed-int=missing TypeError\n";
+    } catch (TypeError $error) {
+        echo "mixed-int=TypeError\n";
+    }
+
+    try {
+        array_keys($values, '1', arrayKeysMixedArray());
+        echo "mixed-array=missing TypeError\n";
+    } catch (TypeError $error) {
+        echo "mixed-array=TypeError\n";
+    }
+
+    try {
+        array_keys($values, '1', arrayKeysUnionInt());
+        echo "union-int=missing TypeError\n";
+    } catch (TypeError $error) {
+        echo "union-int=TypeError\n";
+    }
 }
 ?>
 --EXPECT--
@@ -87,3 +130,10 @@ array(3) {
   [2]=>
   string(6) "strict"
 }
+array(1) {
+  [0]=>
+  string(6) "string"
+}
+mixed-int=TypeError
+mixed-array=TypeError
+union-int=TypeError


### PR DESCRIPTION
## Summary

Fix the optimized three-argument `array_keys()` path when the `$strict` flag is a runtime-backed expression.

`genArrayKeys()` passed the parsed third argument directly to `php::fn::array_keys_filter()`. Typed property reads and typed user-function returns are represented as `php::Var` at that boundary, while the PHPX helper requires a C++ `bool`, so otherwise valid PHP translated successfully but failed during native compilation.

The fix routes only the strict flag through the optimizer's shared boolean argument resolver. The one- and two-argument fast paths and the existing array/filter ABI are unchanged.

## Semantic invariant

Every valid `array_keys($array, $filter, $strict)` call must:

- accept runtime-backed boolean expressions using PHP's internal-function parameter conversion;
- evaluate each argument exactly once and in source order;
- pass a C++ `bool` to `php::fn::array_keys_filter()`;
- preserve strict versus loose key matching.

## Relevance matrix

| Dimension | Coverage |
|---|---|
| Arity | One, two, and three arguments |
| Strict expression | Literal, fixed local, typed property, typed function return |
| Other arguments | Fixed array plus runtime-backed array/filter returns |
| Ordering | Three side-effecting calls record `array,filter,strict` |
| Result semantics | Integer `1` versus string `'1'` distinguishes loose and strict matching |
| Optimization | Real native artifacts at O0 and O3 |
| Fast/fallback | Optimized direct helper is fixed; named/unpacked fallback is unchanged |
| Value context | Returned arrays are consumed and compared; discarded-result lowering has no separate call path |

## Verification

- New PHPT: PASS (1/1), including native translation, MSVC compilation/link, execution, and EXPECT comparison.
- `phpunit/src/FunctionTest.php`: OK (23 tests, 35 assertions).
- Modified optimizer file: PHP syntax check passed.
- `git diff --check`: passed.
- Original installed compiler reproduces the `php::Var` to `bool` C2664 failure at O0 and O3.
- Patched local source builds and runs the focused reproducer at O0 and O3; both print:

```text
literal=string
local=string
property=string
dynamic=string
order=array,filter,strict
```

Generated O0/O3 C++ materializes the three dynamic operands in source order and calls `php::toBool()` only for the third operand.

The full PHPUnit suite is not claimed: this Windows environment has unrelated existing failures and stops at a Linux-only profiling configuration. PHPStan is also not claimed because the repository's Composer script references a `phpstan.neon` file absent from this checkout. Non-MSVC backends were not run locally.
