### PR TITLE
fix(attribute): process Attribute nodes in leaveNode for cross-file enum resolution

### DIFF
--- a/src/Transform/RuntimeAttributeFactoryLowering.php
+++ b/src/Transform/RuntimeAttributeFactoryLowering.php
@@ -78,30 +78,6 @@ final class RuntimeAttributeFactoryLowering extends NodeVisitorAbstract
             return null;
         }
 
-        if (!$node instanceof Node\Attribute) {
-            return null;
-        }
-        if (CompileTimeAttributeRegistry::get($node->name->toString()) !== null) {
-            return null;
-        }
-
-        foreach ($node->args as $argument) {
-            if (!$this->requiresFactory($argument->value)) {
-                continue;
-            }
-
-            $factory = $this->createFactory($argument->value);
-            $argument->value->setAttribute(self::FACTORY_NAME_ATTRIBUTE, $factory['fullName']);
-            if ($this->requiresLazyValue($argument->value)) {
-                $argument->value->setAttribute(self::FACTORY_LAZY_VALUE_ATTRIBUTE, true);
-            }
-            if ($this->namespaceFactories !== []) {
-                $index = array_key_last($this->namespaceFactories);
-                $this->namespaceFactories[$index][] = $factory['node'];
-            } else {
-                $this->globalFactories[] = $factory['node'];
-            }
-        }
         return null;
     }
 
@@ -115,6 +91,33 @@ final class RuntimeAttributeFactoryLowering extends NodeVisitorAbstract
                 array_push($node->stmts, ...$factories);
             }
             $this->namespace = '';
+        } elseif ($node instanceof Node\Attribute) {
+            // Process attribute args in leaveNode so that NameResolver has
+            // already resolved all Name nodes in the argument expressions.
+            // Using enterNode would see unresolved Name('IdType') instead of
+            // Name\FullyQualified('App\\Enums\\IdType'), causing enum case
+            // detection to fail for cross-file enums.
+            if (CompileTimeAttributeRegistry::get($node->name->toString()) !== null) {
+                return null;
+            }
+
+            foreach ($node->args as $argument) {
+                if (!$this->requiresFactory($argument->value)) {
+                    continue;
+                }
+
+                $factory = $this->createFactory($argument->value);
+                $argument->value->setAttribute(self::FACTORY_NAME_ATTRIBUTE, $factory['fullName']);
+                if ($this->requiresLazyValue($argument->value)) {
+                    $argument->value->setAttribute(self::FACTORY_LAZY_VALUE_ATTRIBUTE, true);
+                }
+                if ($this->namespaceFactories !== []) {
+                    $index = array_key_last($this->namespaceFactories);
+                    $this->namespaceFactories[$index][] = $factory['node'];
+                } else {
+                    $this->globalFactories[] = $factory['node'];
+                }
+            }
         }
         return null;
     }
@@ -271,9 +274,8 @@ final class RuntimeAttributeFactoryLowering extends NodeVisitorAbstract
                     }
                 }
                 if ($node instanceof Node\Name) {
-                    // Attribute factories are created while the outer
-                    // traverser is entering the Attribute node, before its
-                    // argument names have been visited by NameResolver.
+                    // Attribute factories are created in leaveNode after
+                    // NameResolver has resolved all Name nodes.
                     if ($node instanceof Node\Name\Relative) {
                         $name = ltrim($this->namespace . '\\' . $node->toString(), '\\');
                         return new Node\Name\FullyQualified($name, $node->getAttributes());


### PR DESCRIPTION
## Bug

When an enum from a different file is used as an attribute argument (e.g. `#[TableId(IdType::AUTO)]`), the `RuntimeAttributeFactoryLowering` pass fails to detect the enum case and does not mark the factory as lazy. The PHPX bridge then stores the raw string backing value instead of calling the factory function, causing a `TypeError` at runtime.

```
TypeError: The parameter 'object' must be 'object', got 'string'
```

## Root Cause

`RuntimeAttributeFactoryLowering` processed `Attribute` nodes in `enterNode()`. At that point, `NodeTraverser` has not yet descended into the Attribute's argument expressions, so `NameResolver` hasn't resolved `Name('IdType')` → `Name\FullyQualified('App\Enums\IdType')`.

The fallback in `resolveClassConstFetchClass()` uses `$this->namespace . '\\' . $name`, producing the wrong namespace (e.g. `App\BenchModels\IdType`), so `isDeclaredEnumCase()` returns `false` and the factory is not marked as lazy.

### Traversal Order Issue

```
NodeTraverser::traverse()
  ├─ enterNode(Attribute)          ← RAF runs here, sees Name('IdType') UNRESOLVED
  │   └─ foreach args
  │       └─ requiresFactory() → true
  │       └─ isEnumCaseFetch() → false (wrong namespace)
  │       └─ factory created but NOT marked lazy
  └─ traverse children
      └─ enterNode(Name('IdType')) ← NameResolver resolves here, TOO LATE
          └─ replaced with FullyQualified('App\Enums\IdType')
```

## Fix

Move Attribute argument processing from `enterNode()` to `leaveNode()`. In `leaveNode()`, all child nodes have been traversed and `NameResolver` has replaced `Name` nodes with `Name\FullyQualified` nodes containing correct `resolvedName` attributes, allowing `isEnumCaseFetch()` to correctly identify enum cases across files.

### Files Changed

`src/Transform/RuntimeAttributeFactoryLowering.php` — 29 lines added, 27 removed (net +2)

### Before (broken)

```php
public function enterNode(Node $node) {
    // ...
    } elseif ($node instanceof Node\Attribute) {
        // $argument->value may contain Name('IdType') — UNRESOLVED
        // → resolveClassConstFetchClass() falls back to wrong namespace
        // → isEnumCaseFetch() returns false → factory NOT marked lazy
    }
}
```

### After (fixed)

```php
public function leaveNode(Node $node) {
    // ...
    } elseif ($node instanceof Node\Attribute) {
        // $argument->value now contains Name\FullyQualified('App\Enums\IdType')
        // → isEnumCaseFetch() correctly resolves cross-file enums
        // → factory marked as lazy → PHPX bridge calls factory function
    }
}
```

## Reproduction

```php
// Status.php — enum in separate file
namespace App;
enum Status: string { case Active = 'active'; }

// Label.php — attribute with enum default
#[Attribute(Attribute::TARGET_CLASS)]
class Label {
    public function __construct(public Status $status = Status::Active) {}
}

// User.php — uses enum attribute from different file
#[Label(Status::Active)]
class User {}
```

| Mode | Result |
|---|---|
| PHP interpreter | ✅ works |
| Compiled (before fix) | ❌ `TypeError: must be 'object', got 'string'` |
| Compiled (after fix) | ✅ works |