### PR TITLE
fix(parser): parenthesize unary minus operand to avoid C++ pre-decrement pasting

### DIFF
--- a/src/Parser/UnaryExpressionTrait.php
+++ b/src/Parser/UnaryExpressionTrait.php
@@ -125,6 +125,14 @@ trait UnaryExpressionTrait
         }
         $code = $this->parseExprAsValue($expr->expr);
 
+        // An operand that already starts with `-` (a nested unary minus, a
+        // negative literal) would paste into the C++ pre-decrement token:
+        // `- -$a` -> `--a`. Parenthesize exactly then, so plain literals
+        // keep their compact `-7L` form.
+        if (str_starts_with($code, '-')) {
+            return '-(' . $code . ')';
+        }
+
         return '-' . $code;
     }
 

--- a/tests/compiler/operator/unary-minus-nested.phpt
+++ b/tests/compiler/operator/unary-minus-nested.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Nested unary minus must not emit the C++ pre-decrement token
+--FILE--
+<?php
+
+function negNative(int $x): int
+{
+    return - -$x;
+}
+
+function main(): void
+{
+    $a = 5;
+    $b = - -$a;
+    echo $b, "\n";
+    echo $a, "\n";
+
+    $c = -(-7);
+    echo $c, "\n";
+
+    $f = 1.5;
+    $g = - -$f;
+    echo $g, "\n";
+
+    echo negNative(9), "\n";
+    echo - -(-3), "\n";
+}
+?>
+--EXPECT--
+5
+5
+7
+1.5
+9
+-3


### PR DESCRIPTION
## Problem

`parseUnaryMinus` emits `'-' . $code` without guarding against an operand that itself starts with `-`, so a nested unary minus pastes into the C++ pre-decrement token: `- -$x` compiles to `--x`.

- On a `php::Var` operand the generated translation unit **fails to build**: `error: expression is not assignable`.
- On a native int operand it **builds and silently corrupts the value**:

```php
function negNative(int $x): int {
    return - -$x;   // compiles to `return --x;` → returns 8 for input 9
}
```

## Fix

Parenthesize the operand exactly when its emitted code starts with `-` (a nested unary minus or a negative literal): `- -$x` → `-(-(x))`. Plain literals keep their compact form (`-7L`), so existing generated output is unchanged everywhere the old code was correct. Binary operands are already self-wrapped in parentheses, and unary plus needs no change since it returns the operand unchanged.

## Tests

- New `tests/compiler/operator/unary-minus-nested.phpt`: nested minus on `php::Var`, float, constant (`-(-7)`), triple chain, and the native-int function case above. Expected output verified against PHP 8.4.
- `operator` + `float_edge` + `bigint` suites: 58/59 pass; the single failure (`runtime-int-overflow-return.phpt`) is a pre-existing environment issue (`php::newClosureWithParameters` missing from the local phpx build) and fails identically on master.
- `LocalVariableInitializerTest` literal expectations (`php::Var negative = -7L;`) are preserved — negative literals still emit without parentheses. No new PHPStan errors.