### PR TITLE
fix(optimizer): keep argument side effects when folding is_int/is_float/is_bool

### DIFF
--- a/src/Optimizer/FuncCallOptimizer.php
+++ b/src/Optimizer/FuncCallOptimizer.php
@@ -681,7 +681,16 @@ trait FuncCallOptimizer
         if (count($expr->args) !== 1 || !($expr->args[0] instanceof Node\Arg)) {
             return false;
         }
-        return ($this->detectTypeOfExpr($expr->args[0]->value) === $expectType) ? 'true' : false;
+        $value = $expr->args[0]->value;
+        if ($this->detectTypeOfExpr($value) !== $expectType) {
+            return false;
+        }
+        if ($value instanceof Node\Expr\Variable || $value instanceof Node\Scalar) {
+            return 'true';
+        }
+        // The argument can carry side effects (a call, an increment). Keep
+        // evaluating it, as genIsNull does for native scalar operands.
+        return '((void) (' . $this->parseExprAsValue($value) . '), true)';
     }
 
     // =========================================================================

--- a/tests/compiler/optimizations/is-type-fold-side-effects.phpt
+++ b/tests/compiler/optimizations/is-type-fold-side-effects.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Folded is_int/is_float/is_bool must keep evaluating side-effect arguments
+--FILE--
+<?php
+function intSource(): int
+{
+    echo "int-called\n";
+    return 42;
+}
+
+function floatSource(): float
+{
+    echo "float-called\n";
+    return 1.5;
+}
+
+function boolSource(): bool
+{
+    echo "bool-called\n";
+    return true;
+}
+
+function main(): void
+{
+    if (is_int(intSource())) {
+        echo "is-int\n";
+    }
+    echo is_float(floatSource()) ? "is-float\n" : "not-float\n";
+    $r = is_bool(boolSource());
+    echo $r ? "is-bool\n" : "not-bool\n";
+
+    // Plain variables still fold without extra evaluation.
+    $n = 7;
+    echo is_int($n) ? "var-int\n" : "var-not-int\n";
+}
+?>
+--EXPECT--
+int-called
+is-int
+float-called
+is-float
+bool-called
+is-bool
+var-int


### PR DESCRIPTION
## Problem

`doFoldSsaType` folds a statically type-known `is_int()` / `is_float()` / `is_bool()` call to the literal `true`, discarding the argument expression entirely:

```php
function intSource(): int { echo "int-called\n"; return 42; }

if (is_int(intSource())) { ... }   // compiles to if (true) — intSource() is never invoked
```

The compiled binary skips the call and its side effects silently vanish (verified: `int-called` / `float-called` / `bool-called` all missing from the compiled output, present under PHP).

## Fix

Fold to a bare `true` only when the argument is a plain variable or scalar literal. For any other argument emit `((void)(expr), true)` so the operand is still evaluated — the same pattern `genIsNull` already uses for native scalar operands a few lines below.

## Tests

- New `tests/compiler/optimizations/is-type-fold-side-effects.phpt`: typed function calls as arguments to all three predicates plus the plain-variable fold. Expected output generated from PHP 8.4; compiled output diffs clean.
- `tests/compiler/optimizations/` suite: 35 pass, the 2 failing SSA float-narrowing tests fail identically on master (pre-existing). No new PHPStan errors.