### PR TITLE
fix(resolver): stop corrupting single-segment use const imports

### DIFF
--- a/src/Resolver/DeclarationSymbolTrait.php
+++ b/src/Resolver/DeclarationSymbolTrait.php
@@ -80,11 +80,11 @@ trait DeclarationSymbolTrait
             if ($type === Node\Stmt\Use_::TYPE_FUNCTION) {
                 $this->useFunctions[$alias] = $id;
             } elseif ($type === Node\Stmt\Use_::TYPE_CONSTANT) {
-                $lastIndex = strrpos($id, '\\');
-                $cn = substr($id, $lastIndex + 1);
-                $ns = substr($id, 0, $lastIndex);
-                $fullName = $ns . '\\' . $cn;
-                $this->useConstants[$alias] = $fullName;
+                // $id is already the fully qualified constant name. Splitting
+                // and re-joining it on `\` corrupted single-segment imports:
+                // `use const PHP_EOL;` resolved to `\HP_EOL` because
+                // strrpos() returns false when there is no separator.
+                $this->useConstants[$alias] = $id;
             } else {
                 $idLower = strtolower($id);
                 if ($idLower === 'native_types') {

--- a/tests/compiler/namespace/use-const-single-segment.phpt
+++ b/tests/compiler/namespace/use-const-single-segment.phpt
@@ -1,0 +1,28 @@
+--TEST--
+use const with a single-segment (global) constant name
+--FILE--
+<?php
+namespace App {
+    use const PHP_EOL;
+
+    const ANSWER = 42;
+
+    function hello(): string
+    {
+        return "hello" . PHP_EOL;
+    }
+}
+
+namespace {
+    use const App\ANSWER;
+
+    function main(): void
+    {
+        echo \App\hello();
+        echo ANSWER, "\n";
+    }
+}
+?>
+--EXPECT--
+hello
+42


### PR DESCRIPTION
## Problem

`parseUse` rebuilds the imported constant name by splitting on the last backslash, but `strrpos()` returns `false` for a single-segment name, and `substr($id, false + 1)` drops the first character:

```php
namespace App;

use const PHP_EOL;    // registered as `\HP_EOL`

echo PHP_EOL;         // compiled binary: Undefined constant "HP_EOL"
```

The mangled name is visible verbatim in the runtime error of the compiled program.

## Fix

`$id` is already the fully qualified constant name — store it directly and drop the split/re-join. For multi-segment imports the removed recomposition produced the identical value, so nothing else changes.

## Tests

- New `tests/compiler/namespace/use-const-single-segment.phpt`: a namespaced file importing the global `PHP_EOL` plus a cross-namespace `use const App\ANSWER`. Expected output verified against PHP 8.4; on master the compiled binary dies with `Undefined constant "HP_EOL"`.
- `tests/compiler/namespace/` suite: 34/34 pass. No PHPStan errors on the touched file.