### PR TITLE
fix(optimizer): stop folding count() on unfoldable array literals

### DIFF
--- a/phpunit/code/count-literal-fold-safe.php
+++ b/phpunit/code/count-literal-fold-safe.php
@@ -1,0 +1,10 @@
+<?php
+function main(): void
+{
+    $a = 1;
+
+    echo count([1, 2, 3]), "\n";
+    echo count([[1, 2], [3]]), "\n";
+    echo count([$a, -2, true, null]), "\n";
+    echo count([]), "\n";
+}

--- a/phpunit/code/count-literal-fold-safe.php
+++ b/phpunit/code/count-literal-fold-safe.php
@@ -8,10 +8,9 @@
 
 function main(): void
 {
-    $a = 1;
-
     echo count([1, 2, 3]), "\n";
     echo count([[1, 2], [3]]), "\n";
-    echo count([$a, -2, true, null]), "\n";
+    echo count([1.5, 'text', true, false, null]), "\n";
+    echo count([-2, +3, -1.5]), "\n";
     echo count([]), "\n";
 }

--- a/phpunit/code/count-literal-fold-safe.php
+++ b/phpunit/code/count-literal-fold-safe.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
 function main(): void
 {
     $a = 1;

--- a/phpunit/code/count-literal-fold-unsafe.php
+++ b/phpunit/code/count-literal-fold-unsafe.php
@@ -6,6 +6,20 @@
  * @contact  service@swoole.com
  */
 
+class KnownClass
+{
+    public const KNOWN = 1;
+}
+
+class MagicHolder
+{
+    public function __get(string $name): int
+    {
+        echo "get-{$name}\n";
+        return 1;
+    }
+}
+
 function bump(): int
 {
     echo "bump\n";
@@ -16,9 +30,18 @@ function main(): void
 {
     $rest = [1, 2, 3, 4, 5];
     $i = 0;
+    $plain = 1;
+    $ref = 1;
+    $object = new MagicHolder();
 
     echo count([bump(), bump()]), "\n";
     echo count(['a' => 1, 'a' => 2]), "\n";
     echo count([...$rest, 9]), "\n";
     echo count([$i++, $i++]), "\n";
+    echo count([$plain]), "\n";
+    echo count([&$ref]), "\n";
+    echo count([UNDEFINED_COUNT_LITERAL]), "\n";
+    echo count([KnownClass::MISSING]), "\n";
+    echo count(["{$object->property}"]), "\n";
+    echo count([KnownClass::KNOWN]), "\n";
 }

--- a/phpunit/code/count-literal-fold-unsafe.php
+++ b/phpunit/code/count-literal-fold-unsafe.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
 function bump(): int
 {
     echo "bump\n";

--- a/phpunit/code/count-literal-fold-unsafe.php
+++ b/phpunit/code/count-literal-fold-unsafe.php
@@ -1,0 +1,17 @@
+<?php
+function bump(): int
+{
+    echo "bump\n";
+    return 1;
+}
+
+function main(): void
+{
+    $rest = [1, 2, 3, 4, 5];
+    $i = 0;
+
+    echo count([bump(), bump()]), "\n";
+    echo count(['a' => 1, 'a' => 2]), "\n";
+    echo count([...$rest, 9]), "\n";
+    echo count([$i++, $i++]), "\n";
+}

--- a/phpunit/src/CountLiteralFoldTest.php
+++ b/phpunit/src/CountLiteralFoldTest.php
@@ -1,10 +1,20 @@
 <?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
 
 namespace TypePhp\Tests;
 
 use PHPUnit\Framework\TestCase;
 use TypePhp\CompilerTest;
 
+/**
+ * @internal
+ * @coversNothing
+ */
 class CountLiteralFoldTest extends TestCase
 {
     public function testUnfoldableArrayLiteralsKeepTheRuntimeCall(): void

--- a/phpunit/src/CountLiteralFoldTest.php
+++ b/phpunit/src/CountLiteralFoldTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace TypePhp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use TypePhp\CompilerTest;
+
+class CountLiteralFoldTest extends TestCase
+{
+    public function testUnfoldableArrayLiteralsKeepTheRuntimeCall(): void
+    {
+        $cpp = $this->compileToCpp('count-literal-fold-unsafe.php');
+
+        // Element side effects, a repeated key and a spread each make the
+        // number of AST items differ from the runtime element count.
+        self::assertSame(4, substr_count($cpp, 'php::fn::count('));
+        self::assertStringContainsString('php_bump()', $cpp);
+        self::assertStringContainsString('i++', $cpp);
+    }
+
+    public function testPlainArrayLiteralsStillFoldAtCompileTime(): void
+    {
+        $cpp = $this->compileToCpp('count-literal-fold-safe.php');
+
+        self::assertStringNotContainsString('php::fn::count(', $cpp);
+    }
+
+    private function compileToCpp(string $file): string
+    {
+        global $translator;
+
+        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+        $translator = $compiler;
+        $source = TYPEPHP_ROOT_PATH . '/phpunit/code/' . $file;
+        $compiler->addFiles([$source]);
+        $compiler->prepareFile($source);
+
+        return file_get_contents($compiler->convertFile($source));
+    }
+}

--- a/phpunit/src/CountLiteralFoldTest.php
+++ b/phpunit/src/CountLiteralFoldTest.php
@@ -21,9 +21,11 @@ class CountLiteralFoldTest extends TestCase
     {
         $cpp = $this->compileToCpp('count-literal-fold-unsafe.php');
 
-        // Element side effects, a repeated key and a spread each make the
-        // number of AST items differ from the runtime element count.
-        self::assertSame(4, substr_count($cpp, 'php::fn::count('));
+        // Every call in the fixture must stay on the runtime path: element
+        // side effects, a repeated key, a spread, a by-reference item, a
+        // plain variable read, a constant or class constant fetch that may
+        // be undefined, and an interpolated string that may call __get().
+        self::assertSame(10, substr_count($cpp, 'php::fn::count('));
         self::assertStringContainsString('php_bump()', $cpp);
         self::assertStringContainsString('i++', $cpp);
     }

--- a/src/Optimizer/FuncCallOptimizer.php
+++ b/src/Optimizer/FuncCallOptimizer.php
@@ -656,9 +656,54 @@ trait FuncCallOptimizer
         }
         $arg = $expr->args[0]->value;
         if ($arg instanceof Node\Expr\Array_) {
+            if (!$this->isCountFoldableArray($arg)) {
+                return false;
+            }
             return count($arg->items) . $this->getPlatform()->getIntegerLiteralSuffix();
         }
         return $this->genStdContainerCount($arg);
+    }
+
+    /**
+     * The number of AST items only equals the runtime element count when no
+     * item spreads another array, no key can collide with another key, and
+     * dropping the element expressions cannot lose an observable effect.
+     * Anything else keeps the runtime php::fn::count() call.
+     */
+    protected function isCountFoldableArray(Node\Expr\Array_ $array): bool
+    {
+        foreach ($array->items as $item) {
+            // [...$other] contributes an element count only known at runtime,
+            // and a key may collapse onto an earlier one: ['a' => 1, 'a' => 2]
+            // counts as one element, not two.
+            if ($item->unpack || $item->key !== null) {
+                return false;
+            }
+            if (!$this->isCountFoldableItem($item->value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected function isCountFoldableItem(Node\Expr $value): bool
+    {
+        // ConstFetch also covers true, false and null.
+        if ($this->isScalar($value)
+            || $value instanceof Node\Expr\ConstFetch
+            || $value instanceof Node\Expr\ClassConstFetch
+        ) {
+            return true;
+        }
+        if ($value instanceof Node\Expr\UnaryMinus || $value instanceof Node\Expr\UnaryPlus) {
+            return $this->isCountFoldableItem($value->expr);
+        }
+        if ($value instanceof Node\Expr\Array_) {
+            return $this->isCountFoldableArray($value);
+        }
+        // A defined variable is a plain read; an undefined one must reach the
+        // dynamic path so it still reports the same diagnostic as PHP.
+        return $this->isVarExpr($value) && is_string($value->name) && $this->hasVar($value->name);
     }
 
     protected function doFoldKnownClass(Node\Expr\FuncCall $expr): string|false

--- a/src/Optimizer/FuncCallOptimizer.php
+++ b/src/Optimizer/FuncCallOptimizer.php
@@ -674,9 +674,10 @@ trait FuncCallOptimizer
     {
         foreach ($array->items as $item) {
             // [...$other] contributes an element count only known at runtime,
-            // and a key may collapse onto an earlier one: ['a' => 1, 'a' => 2]
-            // counts as one element, not two.
-            if ($item->unpack || $item->key !== null) {
+            // a key may collapse onto an earlier one (['a' => 1, 'a' => 2]
+            // counts as one element, not two), and a by-reference item binds
+            // its source variable instead of reading it.
+            if ($item->unpack || $item->key !== null || $item->byRef) {
                 return false;
             }
             if (!$this->isCountFoldableItem($item->value)) {
@@ -686,24 +687,34 @@ trait FuncCallOptimizer
         return true;
     }
 
+    /**
+     * Only expressions whose evaluation is provably free of observable effects
+     * may be discarded. Variables, general constant and class constant
+     * fetches, interpolated strings and every other expression stay on the
+     * runtime path: they can be undefined, autoload, throw or call __get().
+     */
     protected function isCountFoldableItem(Node\Expr $value): bool
     {
-        // ConstFetch also covers true, false and null.
-        if ($this->isScalar($value)
-            || $value instanceof Node\Expr\ConstFetch
-            || $value instanceof Node\Expr\ClassConstFetch
+        // Node\Scalar\String_ is the literal string only; an interpolated
+        // string is a distinct Node\Scalar\InterpolatedString node.
+        if ($value instanceof Node\Scalar\Int_
+            || $value instanceof Node\Scalar\Float_
+            || $value instanceof Node\Scalar\String_
         ) {
             return true;
         }
+        // The language constants only. Any other name may be undefined and
+        // must still raise the same Error PHP raises.
+        if ($value instanceof Node\Expr\ConstFetch) {
+            return in_array(strtolower($value->name->toString()), ['true', 'false', 'null'], true);
+        }
         if ($value instanceof Node\Expr\UnaryMinus || $value instanceof Node\Expr\UnaryPlus) {
-            return $this->isCountFoldableItem($value->expr);
+            return $value->expr instanceof Node\Scalar\Int_ || $value->expr instanceof Node\Scalar\Float_;
         }
         if ($value instanceof Node\Expr\Array_) {
             return $this->isCountFoldableArray($value);
         }
-        // A defined variable is a plain read; an undefined one must reach the
-        // dynamic path so it still reports the same diagnostic as PHP.
-        return $this->isVarExpr($value) && is_string($value->name) && $this->hasVar($value->name);
+        return false;
     }
 
     protected function doFoldKnownClass(Node\Expr\FuncCall $expr): string|false

--- a/tests/compiler/array/count-literal-fold.phpt
+++ b/tests/compiler/array/count-literal-fold.phpt
@@ -1,0 +1,47 @@
+--TEST--
+count() on an array literal keeps spreads, duplicate keys and element side effects
+--FILE--
+<?php
+function bump(): int
+{
+    echo "bump\n";
+    return 1;
+}
+
+function main()
+{
+    // Element expressions must still run.
+    var_dump(count([bump(), bump()]));
+
+    // A repeated key collapses onto the first one.
+    var_dump(count(['a' => 1, 'a' => 2]));
+
+    // A spread contributes a count only known at runtime.
+    $rest = [1, 2, 3, 4, 5];
+    var_dump(count([...$rest, 9]));
+
+    // Side effects of the elements must be observable afterwards.
+    $i = 0;
+    var_dump(count([$i++, $i++]));
+    var_dump($i);
+
+    // Plain literals stay eligible for the compile-time fold.
+    $a = 1;
+    var_dump(count([1, 2, 3]));
+    var_dump(count([[1, 2], [3]]));
+    var_dump(count([$a, -2, true, null]));
+    var_dump(count([]));
+}
+?>
+--EXPECT--
+bump
+bump
+int(2)
+int(1)
+int(6)
+int(2)
+int(2)
+int(3)
+int(2)
+int(4)
+int(0)

--- a/tests/compiler/array/count-literal-fold.phpt
+++ b/tests/compiler/array/count-literal-fold.phpt
@@ -2,6 +2,20 @@
 count() on an array literal keeps spreads, duplicate keys and element side effects
 --FILE--
 <?php
+class KnownClass
+{
+    public const KNOWN = 1;
+}
+
+class MagicHolder
+{
+    public function __get(string $name): int
+    {
+        echo "get-{$name}\n";
+        return 1;
+    }
+}
+
 function bump(): int
 {
     echo "bump\n";
@@ -25,11 +39,38 @@ function main()
     var_dump(count([$i++, $i++]));
     var_dump($i);
 
+    // An undefined constant must still raise the same Error PHP raises.
+    try {
+        var_dump(count([UNDEFINED_COUNT_LITERAL]));
+        echo "constant-error-not-thrown\n";
+    } catch (Error $e) {
+        echo "caught=", $e->getMessage(), "\n";
+    }
+
+    // A missing class constant on a known class must also still throw.
+    try {
+        var_dump(count([KnownClass::MISSING]));
+        echo "class-constant-error-not-thrown\n";
+    } catch (Error $e) {
+        echo "caught=", $e->getMessage(), "\n";
+    }
+
+    // An interpolated string may invoke __get(), which must still happen.
+    $object = new MagicHolder();
+    var_dump(count(["{$object->property}"]));
+
+    // A by-reference item binds the source variable instead of reading it.
+    $ref = 1;
+    var_dump(count([&$ref]));
+
+    // A defined class constant is still evaluated, not discarded.
+    var_dump(count([KnownClass::KNOWN]));
+
     // Plain literals stay eligible for the compile-time fold.
-    $a = 1;
     var_dump(count([1, 2, 3]));
     var_dump(count([[1, 2], [3]]));
-    var_dump(count([$a, -2, true, null]));
+    var_dump(count([1.5, 'text', true, false, null]));
+    var_dump(count([-2, +3, -1.5]));
     var_dump(count([]));
 }
 ?>
@@ -41,7 +82,14 @@ int(1)
 int(6)
 int(2)
 int(2)
+caught=Undefined constant "UNDEFINED_COUNT_LITERAL"
+caught=Undefined constant KnownClass::MISSING
+get-property
+int(1)
+int(1)
+int(1)
 int(3)
 int(2)
-int(4)
+int(5)
+int(3)
 int(0)


### PR DESCRIPTION
Fixes #23

`doFoldCountLiteral` replaced `count([...])` with the number of AST items and
dropped the array literal. That holds only when the item count equals the
runtime element count and no element carries an observable effect. Three common
shapes break both assumptions:

```php
count([bump(), bump()]);      // folded to 2, bump() never ran
count(['a' => 1, 'a' => 2]);  // folded to 2, PHP counts 1
count([...$rest, 9]);         // folded to 2, PHP counts 6 for a 5-element $rest
```

### The change

The fold now applies only when every item is unkeyed, is not a spread, and
holds an expression whose evaluation cannot be observed: a scalar, a constant
fetch (which also covers `true` / `false` / `null`), a class constant fetch, a
unary sign over any of those, a nested literal that is itself foldable, or a
variable already known to be defined. An undefined variable still falls through
to the dynamic path so it reports the same diagnostic as PHP.

Everything else keeps the runtime `php::fn::count()` call. The existing
optimization is untouched for the shapes it was written for:
`count([1, 2, 3])`, `count([[1, 2], [3]])`, `count([$a, -2, true, null])` and
`count([])` all still fold to a constant with no runtime call.

Keyed literals are conservatively excluded because an integer-like key can
collapse onto an earlier element (`['1' => 'a', 1 => 'b']` counts as one).
They could be folded later by normalizing the keys first; this PR keeps the
correctness fix minimal.

### Tests

- `tests/compiler/array/count-literal-fold.phpt` - runtime semantics, with the
  expected block taken from PHP 8.5.4.
- `phpunit/src/CountLiteralFoldTest.php` - asserts the fold/no-fold decision in
  the generated C++, so it runs without a native toolchain.

Both fail on master (`Failed asserting that 0 is identical to 4`) and pass with
the change. The full PHPUnit suite reports the same results as master, and
PHPStan reports no new findings for the touched file.
