### PR TITLE
fix(optimizer): class_exists() must not fold a trait name to true

### DIFF
--- a/phpunit/code/class-exists-class-and-enum.php
+++ b/phpunit/code/class-exists-class-and-enum.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+class Real
+{
+}
+
+enum Suit
+{
+    case Hearts;
+}
+
+function main(): void
+{
+    var_dump(class_exists('Real'));
+    var_dump(class_exists('Suit'));
+}

--- a/phpunit/code/class-exists-trait.php
+++ b/phpunit/code/class-exists-trait.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+trait Helper
+{
+}
+
+function main(): void
+{
+    var_dump(class_exists('Helper'));
+}

--- a/phpunit/src/ClassExistsTraitFoldTest.php
+++ b/phpunit/src/ClassExistsTraitFoldTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+namespace TypePhp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use TypePhp\CompilerTest;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class ClassExistsTraitFoldTest extends TestCase
+{
+    public function testTraitNameFoldsToFalse(): void
+    {
+        $cpp = $this->compileToCpp('class-exists-trait.php');
+
+        // The trait is known at compile time, so the call is still folded -
+        // just to the answer PHP gives, which is false for a trait.
+        self::assertStringNotContainsString('php::fn::class_exists(', $cpp);
+        self::assertStringContainsString('= false;', $cpp);
+    }
+
+    public function testClassAndEnumNamesStillFoldToTrue(): void
+    {
+        $cpp = $this->compileToCpp('class-exists-class-and-enum.php');
+
+        self::assertStringNotContainsString('php::fn::class_exists(', $cpp);
+        self::assertStringNotContainsString('= false;', $cpp);
+    }
+
+    private function compileToCpp(string $file): string
+    {
+        global $translator;
+
+        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+        $translator = $compiler;
+        $source = TYPEPHP_ROOT_PATH . '/phpunit/code/' . $file;
+        $compiler->addFiles([$source]);
+        $compiler->prepareFile($source);
+
+        return file_get_contents($compiler->convertFile($source));
+    }
+}

--- a/src/Optimizer/FuncCallOptimizer.php
+++ b/src/Optimizer/FuncCallOptimizer.php
@@ -667,6 +667,11 @@ trait FuncCallOptimizer
         if (!$this->isScalarString($cn) || !$this->hasClass($cn->value)) {
             return false;
         }
+        // The class table also carries traits, but a trait is not a class to
+        // class_exists(): PHP answers false for it and true for an enum.
+        if ($this->getClassDef($cn->value)?->trait !== null) {
+            return 'false';
+        }
         return $this->isNativeObjectClass($cn->value) ? 'false' : 'true';
     }
 

--- a/tests/compiler/stdlib/class_exists.phpt
+++ b/tests/compiler/stdlib/class_exists.phpt
@@ -16,6 +16,12 @@ function main() {
     var_dump(class_exists("NonexistentClass"));
     var_dump(class_exists("NonexistentClass", false));
 
+    // A trait is not a class. The answer must not depend on whether the name
+    // is a literal the compiler can resolve at compile time.
+    var_dump(class_exists("MyTrait"));
+    $traitName = "MyTrait";
+    var_dump(class_exists($traitName));
+
     // interface_exists
     var_dump(interface_exists("MyInterface"));
     var_dump(interface_exists("NonexistentInterface"));
@@ -36,6 +42,8 @@ function main() {
 --EXPECT--
 bool(true)
 bool(true)
+bool(false)
+bool(false)
 bool(false)
 bool(false)
 bool(true)


### PR DESCRIPTION
Fixes #25

`doFoldKnownClass` folds `class_exists()` whenever the symbol table knows the
literal name. Traits live in that table, so a trait folded to `true`:

```php
trait Helper {}

class_exists('Helper');   // folded to true
$name = 'Helper';
class_exists($name);      // reaches php::fn::class_exists, answers false
```

PHP answers `false` for both. So does this compiler's runtime - traits are
compile-time AST templates here, which is why
`tests/compiler/stdlib/class_exists.phpt` already expects `trait_exists()` to be
`false`. Only the fold disagreed, and only for a literal argument.

### The change

A trait name folds to `false`. Classes and enums are untouched and keep folding
to `true`, matching PHP, where an enum is a class and a trait is not. Interfaces
already fell through to the runtime call, so they are unaffected.

### Tests

- `tests/compiler/stdlib/class_exists.phpt` gains the two missing cases: the
  trait name as a literal and through a variable. The file already covered
  `class_exists` for a class and `trait_exists` for a trait, but never
  `class_exists` for a trait.
- `phpunit/src/ClassExistsTraitFoldTest.php` pins the fold decision in the
  generated C++ and runs without a native toolchain.

The PHPUnit test fails on master and passes with the change. The full suite
reports the same results as master, and PHPStan reports no new findings for the
touched file.
