### PR TITLE
fix(optimizer): round() must not lower a RoundingMode enum to an int

### DIFF
--- a/phpunit/code/round-native-path.php
+++ b/phpunit/code/round-native-path.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+function main(): void
+{
+    var_dump(round(2.5));
+    var_dump(round(2.567, 2));
+}

--- a/phpunit/code/round-unpacked-mode.php
+++ b/phpunit/code/round-unpacked-mode.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+function main(): void
+{
+    $all = [2.5, 0, PHP_ROUND_HALF_DOWN];
+    $tail = [0, PHP_ROUND_HALF_DOWN];
+
+    var_dump(round(...$all));
+    var_dump(round(2.5, ...$tail));
+}

--- a/phpunit/code/round-with-legacy-mode.php
+++ b/phpunit/code/round-with-legacy-mode.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+function main(): void
+{
+    var_dump(round(2.5, 0, PHP_ROUND_HALF_DOWN));
+}

--- a/phpunit/code/round-with-mode.php
+++ b/phpunit/code/round-with-mode.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+function main(): void
+{
+    var_dump(round(2.5, 0, RoundingMode::HalfEven));
+}

--- a/phpunit/src/RoundModeTest.php
+++ b/phpunit/src/RoundModeTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+namespace TypePhp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use TypePhp\CompilerTest;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class RoundModeTest extends TestCase
+{
+    public function testRoundingModeReachesTheRuntimeUnconverted(): void
+    {
+        global $translator;
+
+        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+        $translator = $compiler;
+        $source = TYPEPHP_ROOT_PATH . '/phpunit/code/round-with-mode.php';
+        $compiler->addFiles([$source]);
+        $compiler->prepareFile($source);
+        $cpp = file_get_contents($compiler->convertFile($source));
+
+        // php::fn::round() models the mode as an Int, so an enum must not be
+        // lowered to it: the conversion turns HalfEven into half away from
+        // zero. The call goes to the runtime with the enum intact instead.
+        self::assertStringNotContainsString('php::fn::round(', $cpp);
+        self::assertStringContainsString('php::constant(', $cpp);
+    }
+
+    public function testLegacyIntegerModeKeepsTheNativeCall(): void
+    {
+        global $translator;
+
+        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+        $translator = $compiler;
+        $source = TYPEPHP_ROOT_PATH . '/phpunit/code/round-with-legacy-mode.php';
+        $compiler->addFiles([$source]);
+        $compiler->prepareFile($source);
+        $cpp = file_get_contents($compiler->convertFile($source));
+
+        self::assertStringContainsString('php::fn::round(', $cpp);
+    }
+}

--- a/phpunit/src/RoundModeTest.php
+++ b/phpunit/src/RoundModeTest.php
@@ -19,14 +19,7 @@ class RoundModeTest extends TestCase
 {
     public function testRoundingModeReachesTheRuntimeUnconverted(): void
     {
-        global $translator;
-
-        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
-        $translator = $compiler;
-        $source = TYPEPHP_ROOT_PATH . '/phpunit/code/round-with-mode.php';
-        $compiler->addFiles([$source]);
-        $compiler->prepareFile($source);
-        $cpp = file_get_contents($compiler->convertFile($source));
+        $cpp = $this->compileToCpp('round-with-mode.php');
 
         // php::fn::round() models the mode as an Int, so an enum must not be
         // lowered to it: the conversion turns HalfEven into half away from
@@ -35,17 +28,44 @@ class RoundModeTest extends TestCase
         self::assertStringContainsString('php::constant(', $cpp);
     }
 
-    public function testLegacyIntegerModeKeepsTheNativeCall(): void
+    public function testLegacyIntegerModeAlsoReachesTheRuntime(): void
+    {
+        $cpp = $this->compileToCpp('round-with-legacy-mode.php');
+
+        // The Native wrapper calls _php_math_round() directly and never
+        // validates the mode, so an out-of-range integer aborts the process
+        // instead of raising ValueError. A statically typed int proves
+        // nothing about the runtime value, so every explicit mode is dynamic.
+        self::assertStringNotContainsString('php::fn::round(', $cpp);
+    }
+
+    public function testUnpackedArgumentsStayOnTheDynamicPath(): void
+    {
+        $cpp = $this->compileToCpp('round-unpacked-mode.php');
+
+        // Both the full and the partial unpack have fewer Node\Arg entries
+        // than runtime arguments, so the syntactic count must not be read.
+        self::assertStringNotContainsString('php::fn::round(', $cpp);
+        self::assertSame(2, substr_count($cpp, 'appendUnpacked('));
+    }
+
+    public function testCallsWithoutAModeKeepTheNativeWrapper(): void
+    {
+        $cpp = $this->compileToCpp('round-native-path.php');
+
+        self::assertSame(2, substr_count($cpp, 'php::fn::round('));
+    }
+
+    private function compileToCpp(string $file): string
     {
         global $translator;
 
         $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
         $translator = $compiler;
-        $source = TYPEPHP_ROOT_PATH . '/phpunit/code/round-with-legacy-mode.php';
+        $source = TYPEPHP_ROOT_PATH . '/phpunit/code/' . $file;
         $compiler->addFiles([$source]);
         $compiler->prepareFile($source);
-        $cpp = file_get_contents($compiler->convertFile($source));
 
-        self::assertStringContainsString('php::fn::round(', $cpp);
+        return file_get_contents($compiler->convertFile($source));
     }
 }

--- a/src/Optimizer/FuncCallOptimizer.php
+++ b/src/Optimizer/FuncCallOptimizer.php
@@ -792,7 +792,7 @@ trait FuncCallOptimizer
         return $array . '.offsetExists(' . $key . ')';
     }
 
-    protected function genRound(string $n, Node\Expr\FuncCall $e, array $c): string
+    protected function genRound(string $n, Node\Expr\FuncCall $e, array $c): string|false
     {
         $type = $this->detectTypeOfExpr($e->args[0]->value);
         if ($type === Type::DECIMAL) {
@@ -804,6 +804,13 @@ trait FuncCallOptimizer
         }
         $args = count($e->args);
         if ($args >= 3) {
+            // php::fn::round() models the mode as an Int, which covers only the
+            // legacy PHP_ROUND_* constants. Since PHP 8.4 the parameter is a
+            // RoundingMode enum: converting it to an int picks a different mode,
+            // so anything that is not statically an int goes to the runtime.
+            if ($this->detectTypeOfExpr($e->args[2]->value) !== Type::INT) {
+                return false;
+            }
             return 'php::fn::round(' . $this->getArg($e, 0) . ', ' . $this->convertIntExpr($this->getArg($e, 1)) . ', ' . $this->convertIntExpr($this->getArg($e, 2)) . ')';
         }
         if ($args >= 2) {

--- a/src/Optimizer/FuncCallOptimizer.php
+++ b/src/Optimizer/FuncCallOptimizer.php
@@ -794,6 +794,14 @@ trait FuncCallOptimizer
 
     protected function genRound(string $n, Node\Expr\FuncCall $e, array $c): string|false
     {
+        // An unpacked or named argument is a single Node\Arg whatever its
+        // runtime arity turns out to be, so the syntactic count below cannot
+        // stand in for the real one and no position may be read directly.
+        foreach ($e->args as $arg) {
+            if (!$arg instanceof Node\Arg || $arg->unpack || $arg->name !== null) {
+                return false;
+            }
+        }
         $type = $this->detectTypeOfExpr($e->args[0]->value);
         if ($type === Type::DECIMAL) {
             $a0 = $this->parseExpr($e->args[0]->value);
@@ -804,14 +812,14 @@ trait FuncCallOptimizer
         }
         $args = count($e->args);
         if ($args >= 3) {
-            // php::fn::round() models the mode as an Int, which covers only the
-            // legacy PHP_ROUND_* constants. Since PHP 8.4 the parameter is a
-            // RoundingMode enum: converting it to an int picks a different mode,
-            // so anything that is not statically an int goes to the runtime.
-            if ($this->detectTypeOfExpr($e->args[2]->value) !== Type::INT) {
-                return false;
-            }
-            return 'php::fn::round(' . $this->getArg($e, 0) . ', ' . $this->convertIntExpr($this->getArg($e, 1)) . ', ' . $this->convertIntExpr($this->getArg($e, 2)) . ')';
+            // php::fn::round() models the mode as an Int and calls
+            // _php_math_round() directly, bypassing Zend's validation of the
+            // parameter. A RoundingMode enum lowered to an int selects a
+            // different mode, and an out-of-range int aborts the process in
+            // php_round_helper instead of raising ValueError. A static int
+            // type does not prove the runtime value is one of the eight valid
+            // modes, so every explicit mode goes to the dynamic Zend path.
+            return false;
         }
         if ($args >= 2) {
             return 'php::fn::round(' . $this->getArg($e, 0) . ', ' . $this->convertIntExpr($this->getArg($e, 1)) . ')';

--- a/tests/compiler/stdlib/round-mode.phpt
+++ b/tests/compiler/stdlib/round-mode.phpt
@@ -1,0 +1,56 @@
+--TEST--
+round() with an explicit mode is validated by Zend, not by the Native wrapper
+--FILE--
+<?php
+function main()
+{
+    // A valid legacy mode still produces PHP's result.
+    var_dump(round(2.5, 0, PHP_ROUND_HALF_DOWN));
+    var_dump(round(3.5, 0, PHP_ROUND_HALF_ODD));
+
+    // An out-of-range integer mode must raise ValueError. The Native wrapper
+    // calls _php_math_round() directly, where the same value aborts the
+    // process inside php_round_helper.
+    try {
+        var_dump(round(2.5, 0, 99));
+        echo "value-error-not-thrown\n";
+    } catch (ValueError $e) {
+        echo "caught=", $e->getMessage(), "\n";
+    }
+    try {
+        var_dump(round(2.5, 0, 0));
+        echo "value-error-not-thrown\n";
+    } catch (ValueError $e) {
+        echo "caught=", $e->getMessage(), "\n";
+    }
+
+    // A statically typed int says nothing about the runtime value either.
+    $mode = 99;
+    try {
+        var_dump(round(2.5, 0, $mode));
+        echo "value-error-not-thrown\n";
+    } catch (ValueError $e) {
+        echo "caught=", $e->getMessage(), "\n";
+    }
+
+    // Unpacking hides the real arity from the syntactic argument count.
+    $all = [2.5, 0, PHP_ROUND_HALF_DOWN];
+    var_dump(round(...$all));
+    $tail = [0, PHP_ROUND_HALF_DOWN];
+    var_dump(round(2.5, ...$tail));
+
+    // Calls without an explicit mode keep the native wrapper.
+    var_dump(round(2.5));
+    var_dump(round(2.567, 2));
+}
+?>
+--EXPECT--
+float(2)
+float(3)
+caught=round(): Argument #3 ($mode) must be a valid rounding mode (RoundingMode::*)
+caught=round(): Argument #3 ($mode) must be a valid rounding mode (RoundingMode::*)
+caught=round(): Argument #3 ($mode) must be a valid rounding mode (RoundingMode::*)
+float(2)
+float(2)
+float(3)
+float(2.57)


### PR DESCRIPTION
Refs #29

`php::fn::round()` declares the mode as an `Int`, which models only the legacy
`PHP_ROUND_*` constants. Since PHP 8.4 the parameter is a `RoundingMode` enum,
and `genRound` sent it through `convertIntExpr` regardless. The object-to-int
conversion yields 1, `PHP_ROUND_HALF_UP`, so banker's rounding silently became
half away from zero.

### The change

Every call with an explicit third argument now falls through to the dynamic
Zend path. The one and two argument forms are untouched and keep the native
wrapper.

The first revision of this PR only rerouted a mode that was not statically an
int. As @matyhtf pointed out in review, that is not sufficient: the Native
wrapper calls `_php_math_round()` directly and never runs Zend's validation, so
an integer outside 1-8 reaches `php_round_helper` and takes the process down.
On this machine `round(2.5, 0, 99)` compiled with the first revision is a plain
segmentation fault; on the dynamic path it raises the expected
`ValueError: round(): Argument #3 ($mode) must be a valid rounding mode`. A
static int type says nothing about the runtime value, so an int variable
reaches the same place, and three argument `round()` is uncommon enough that
the conservative route is the right trade.

Unpacked and named arguments are rejected as well. Both carry a single
`Node\Arg` whatever their runtime arity turns out to be, so `genRound()` was
reading the unpacked array itself as the number being rounded.

### Verified on a binary

PHP 8.5.4 ZTS with embed, GCC 15, Linux x64:

| phpx | genRound | `round(2.5, 0, RoundingMode::HalfEven)` | `round(2.5, 0, 99)` |
| --- | --- | --- | --- |
| master | master | stack smashing abort | segmentation fault |
| master | first revision | clean TypeError, no memory corruption | segmentation fault |
| master | this revision | clean TypeError, no memory corruption | `ValueError`, as PHP |
| swoole/phpx#98 | this revision | `2`, same as PHP | `ValueError`, as PHP |

### Tests

`phpunit/src/RoundModeTest.php` pins the lowering decisions in the generated
C++: an enum mode, a legacy integer mode and both unpack forms must all stay
off `php::fn::round(`, while the one and two argument calls must keep it.

`tests/compiler/stdlib/round-mode.phpt` now covers the runtime behaviour that
does not depend on phpx: valid legacy modes, out-of-range literal and variable
modes, and full and partial unpacking.

The enum case is still not in the runtime coverage. swoole/phpx#98 is merged,
but the pinned `swoole/phpx ~2.6.7` currently resolves to v2.6.8 (`4532c4df`),
which predates it, so `RoundingMode::HalfEven` still does not materialise and
the call ends in `TypeError: round(): Argument #3 ($mode) must be of type
RoundingMode|int, int|float given`. I have left `Fixes #29` off this PR for
that reason. Once the dependency is bumped past `8d2ca8e9` I am happy to send
the enum PHPT as a follow-up, or to add it here if you would rather land both
together.
