### PR TITLE
fix(generator): float constants must not be truncated by the precision ini

### DIFF
--- a/phpunit/code/float-constant-precision.php
+++ b/phpunit/code/float-constant-precision.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+function main(): void
+{
+    var_dump(M_E);
+    var_dump(log(M_E));
+}

--- a/phpunit/src/CompilerBaseApiTest.php
+++ b/phpunit/src/CompilerBaseApiTest.php
@@ -361,7 +361,9 @@ PHP);
 
     public function testGeneratedCValuesAreAlwaysSourceCodeStrings(): void
     {
-        $this->assertSame((string) M_E, $this->invokeMethod('genCValue', M_E));
+        // A string cast here would follow the precision ini, so the assertion
+        // is that the emitted literal reads back as the same double.
+        $this->assertSame(M_E, (float) $this->invokeMethod('genCValue', M_E));
         $this->assertSame('1', $this->invokeMethod('genCValue', true));
         $this->assertSame('0', $this->invokeMethod('genCValue', false));
 
@@ -370,7 +372,7 @@ PHP);
             new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('M_E'))
         );
         $this->assertIsString($code);
-        $this->assertSame((string) M_E, $code);
+        $this->assertSame(M_E, (float) $code);
     }
 
     public function testNumericStringIdentifiersGenerateSourceCodeStrings(): void

--- a/phpunit/src/FloatLiteralPrecisionTest.php
+++ b/phpunit/src/FloatLiteralPrecisionTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+namespace TypePhp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use TypePhp\CompilerTest;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class FloatLiteralPrecisionTest extends TestCase
+{
+    public function testFloatConstantsIgnoreThePrecisionIniOfTheHost(): void
+    {
+        // precision=14 is the PHP default, so this is what most hosts compile
+        // with. The constant baked into the binary must not depend on it.
+        $previous = ini_set('precision', '14');
+
+        try {
+            $cpp = $this->compileToCpp('float-constant-precision.php');
+        } finally {
+            if ($previous !== false) {
+                ini_set('precision', $previous);
+            }
+        }
+
+        self::assertStringContainsString('2.7182818284590451', $cpp);
+        self::assertStringNotContainsString('2.718281828459)', $cpp);
+    }
+
+    private function compileToCpp(string $file): string
+    {
+        global $translator;
+
+        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+        $translator = $compiler;
+        $source = TYPEPHP_ROOT_PATH . '/phpunit/code/' . $file;
+        $compiler->addFiles([$source]);
+        $compiler->prepareFile($source);
+
+        return file_get_contents($compiler->convertFile($source));
+    }
+}

--- a/phpunit/src/Generator/UtilsTest.php
+++ b/phpunit/src/Generator/UtilsTest.php
@@ -49,7 +49,12 @@ class UtilsTest extends TestCase
     public function testGenCValueFloat(): void
     {
         $result = $this->invokeMethod('genCValue', 3.14);
-        $this->assertSame((string) 3.14, $result);
+
+        // The literal has to read back as the same double. Its exact spelling
+        // is not part of the contract, but a string cast would depend on the
+        // precision ini and lose digits.
+        $this->assertSame(3.14, (float) $result);
+        $this->assertMatchesRegularExpression('/[.E]/i', $result);
     }
 
     public function testGenCValueBool(): void

--- a/src/Generator/Utils.php
+++ b/src/Generator/Utils.php
@@ -31,7 +31,9 @@ trait Utils
             return $this->genIntegerLiteral($value);
         }
         if (is_float($value)) {
-            return (string) $value;
+            // A string cast formats with the precision ini, which defaults to
+            // 14 and would bake a truncated constant into the binary.
+            return $this->genFloatLiteral($value);
         }
         if (is_bool($value)) {
             return $value ? '1' : '0';


### PR DESCRIPTION
Fixes #31

`genCValue()` lowered a float with a string cast, which formats using the
`precision` ini. That defaults to 14, so a constant baked into the binary lost
digits whenever the host PHP was not configured otherwise:

```cpp
// compiled by a host with the default precision=14
php::Var e = 2.718281828459;   // M_E
php::fn::log(2.718281828459);  // 0.9999999999999832, PHP gives 1
```

The value is wrong in the binary itself, so nothing at runtime recovers it, and
the same source compiled on two differently configured hosts produces two
different programs.

### The change

`BinaryOpTrait::genFloatLiteral()` already formats with `%.17g` and keeps the
literal a C++ double. `genCValue()` was simply not using it, so the same double
was spelled two ways depending on which path emitted it. One line, and both
paths now agree.

### Three existing tests go green

`run-tests.php` sets `precision=14` itself, so these fail on master on a
checkout without a precision override, and pass with this change:

```
tests/compiler/basic/math_functions.phpt
tests/compiler/class/readonly-class.phpt
tests/compiler/type_decl/union-intersection-types.phpt
```

Verified against a real build: PHP 8.5.4 ZTS with embed, GCC 15, Linux x64.
They pass in CI today only because the workflow sets `precision=17`.

### Two unit tests updated, on purpose

`UtilsTest::testGenCValueFloat` and
`CompilerBaseApiTest::testGeneratedCValuesAreAlwaysSourceCodeStrings` asserted
the output by comparing against `(string) $value` - the precision-dependent cast
itself, so they pinned the behaviour rather than the requirement. They now
assert that the emitted literal reads back as the same double, which is what the
generated code actually needs. `FloatLiteralPrecisionTest` covers the regression
head-on by compiling with `precision=14` set.

The rest of the PHPUnit suite reports the same results as master, and PHPStan
reports no findings for the touched file.
