### PR TITLE
fix(preprocessor): recompute method override flags after all files prepared

### DIFF
--- a/phpunit/code/devirtualize-order/base.php
+++ b/phpunit/code/devirtualize-order/base.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OrderTest;
+
+class Base
+{
+    protected function perform(): string
+    {
+        return 'base';
+    }
+
+    public function delete(): string
+    {
+        return $this->perform();
+    }
+}

--- a/phpunit/code/devirtualize-order/leaf.php
+++ b/phpunit/code/devirtualize-order/leaf.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace OrderTest;
+
+class Leaf extends Mid
+{
+    protected function perform(): string
+    {
+        return 'leaf';
+    }
+}

--- a/phpunit/code/devirtualize-order/mid.php
+++ b/phpunit/code/devirtualize-order/mid.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace OrderTest;
+
+class Mid extends Base
+{
+}

--- a/phpunit/src/DevirtualizeOrderTest.php
+++ b/phpunit/src/DevirtualizeOrderTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+namespace TypePhp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use TypePhp\CompilerTest;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class DevirtualizeOrderTest extends TestCase
+{
+    public function testSandwichDeclarationOrderKeepsOverrideDynamic(): void
+    {
+        // Ancestor first, leaf second, intermediate class last: the ancestor
+        // method's override flag used to be missed, and the late-bound call
+        // in Base::delete() was wrongly devirtualized to a direct native call.
+        $cpp = $this->compileBaseInOrder(['base.php', 'leaf.php', 'mid.php']);
+        $this->assertDeleteDispatchesDynamically($cpp);
+    }
+
+    public function testNormalDeclarationOrderKeepsOverrideDynamic(): void
+    {
+        // Control: ancestor, intermediate, leaf.
+        $cpp = $this->compileBaseInOrder(['base.php', 'mid.php', 'leaf.php']);
+        $this->assertDeleteDispatchesDynamically($cpp);
+    }
+
+    /** @param list<string> $order */
+    private function compileBaseInOrder(array $order): string
+    {
+        global $translator;
+
+        $dir = TYPEPHP_ROOT_PATH . '/phpunit/code/devirtualize-order';
+        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+        $translator = $compiler;
+        foreach ($order as $file) {
+            $compiler->addFiles([$dir . '/' . $file]);
+            $compiler->prepareFile($dir . '/' . $file);
+        }
+
+        return file_get_contents($compiler->convertFile($dir . '/base.php'));
+    }
+
+    private function assertDeleteDispatchesDynamically(string $cpp): void
+    {
+        $matched = preg_match(
+            '/php::\w+ php_ordertest__base__delete\(php::Object &this_\) \{(?<body>.*?)\n\}/s',
+            $cpp,
+            $m,
+        );
+        self::assertSame(1, $matched, 'generated body of OrderTest\\Base::delete() not found');
+        // A direct native call to the base implementation means the override
+        // was wrongly devirtualized; the call must go through dynamic dispatch.
+        self::assertStringNotContainsString('php_ordertest__base__perform', $m['body']);
+        self::assertStringContainsString('callScoped', $m['body']);
+    }
+}

--- a/src/CompilerBase.php
+++ b/src/CompilerBase.php
@@ -333,6 +333,7 @@ class CompilerBase implements PropertyAccessContext
     /** @var array<string, array<Node\Stmt>> Prepared declaration ASTs keyed by real path. */
     protected array $preparedFileAsts = [];
     protected bool $declarationExpressionsFinalized = false;
+    protected bool $methodOverrideFlagsFinalized = false;
     protected const array PHP_RUNTIME_TYPE_MAP = [
         'integer' => Type::INT,
         'double' => Type::FLOAT,

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -317,6 +317,9 @@ class Preprocessor extends CompilerBase
             // generated until the complete symbol table is available.
             $this->preparedFileAsts[$this->file] = $stmts;
             $this->declarationExpressionsFinalized = false;
+            // The prepared class graph changed; override flags must be
+            // re-finalized before the next conversion.
+            $this->methodOverrideFlagsFinalized = false;
             // CompilerTest and embedding users may invoke prepareFile()
             // directly instead of the project pipeline. Preserve same-file
             // forward Native references for that public entry path as well.
@@ -2162,6 +2165,46 @@ class Preprocessor extends CompilerBase
         }
 
         $this->resetMethod();
+    }
+
+    /**
+     * Finalize the classMethodOverride flags once the complete class graph is
+     * known.
+     *
+     * The incremental registration in prepareClassMethod() depends on file
+     * preprocessing order: with a "sandwich" order (ancestor first, leaf
+     * second, intermediate class last), the ancestor method's override flag is
+     * missed, causing MethodCallTrait::findNativeMethod() to devirtualize a
+     * call that should be dynamically dispatched.
+     *
+     * Runs once per class-graph change, before conversion starts. For every
+     * declared method it walks the complete parent chain and marks each
+     * ancestor method of the same name as overridden, following the existing
+     * upward-marking semantics. This is order-independent and costs roughly
+     * method count x inheritance depth.
+     */
+    protected function finalizeMethodOverrideFlags(): void
+    {
+        $this->assertCompilerPhase(self::PHASE_CONVERT, 'method override flag finalization');
+        if ($this->methodOverrideFlagsFinalized) {
+            return;
+        }
+        $this->methodOverrideFlagsFinalized = true;
+        foreach (array_keys($this->classMethodOverride) as $fullMethodNameLower) {
+            $pos = strrpos($fullMethodNameLower, '::');
+            if ($pos === false) {
+                continue;
+            }
+            $methodLower = substr($fullMethodNameLower, $pos + 2);
+            $classLower = substr($fullMethodNameLower, 0, $pos);
+            while (($parentClass = $this->symbols->parent($classLower)) !== '') {
+                $parentMethodLower = strtolower($parentClass) . '::' . $methodLower;
+                if (isset($this->classMethodOverride[$parentMethodLower])) {
+                    $this->classMethodOverride[$parentMethodLower] = true;
+                }
+                $classLower = strtolower($parentClass);
+            }
+        }
     }
 
     private function assertKeywordMethodMayBeDeclared(

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -548,6 +548,7 @@ class Translator extends Preprocessor
             if (!$this->declarationExpressionsFinalized) {
                 $this->finalizeDeclarationExpressions(array_keys($this->preparedFileAsts));
             }
+            $this->finalizeMethodOverrideFlags();
             $file = realpath($file);
             $phpCode = $this->loadFile($file);
             $this->localHeaders = [];

--- a/tests/compiler/devirtualize/override-order-normal.phpt
+++ b/tests/compiler/devirtualize/override-order-normal.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Devirtualize: override flag with normal declaration order (ancestor, intermediate, leaf) - control
+--FILE--
+<?php
+
+class OrderedBase {
+    protected function perform(): string {
+        return "base";
+    }
+
+    public function delete(): string {
+        return $this->perform();
+    }
+}
+
+class OrderedMid extends OrderedBase {
+}
+
+class OrderedLeaf extends OrderedMid {
+    protected function perform(): string {
+        return "leaf";
+    }
+}
+
+function main() {
+    var_dump((new OrderedLeaf())->delete());
+}
+
+?>
+--EXPECT--
+string(4) "leaf"

--- a/tests/compiler/devirtualize/override-order-sandwich.phpt
+++ b/tests/compiler/devirtualize/override-order-sandwich.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Devirtualize: override flag survives sandwich declaration order (ancestor, leaf, intermediate)
+--FILE--
+<?php
+
+class SandwichBase {
+    protected function perform(): string {
+        return "base";
+    }
+
+    public function delete(): string {
+        return $this->perform();
+    }
+}
+
+// Leaf is declared before its parent SandwichMid: the override flag of
+// SandwichBase::perform() must still be registered, so the late-bound call
+// in delete() stays dynamic.
+class SandwichLeaf extends SandwichMid {
+    protected function perform(): string {
+        return "leaf";
+    }
+}
+
+class SandwichMid extends SandwichBase {
+}
+
+function main() {
+    var_dump((new SandwichLeaf())->delete());
+}
+
+?>
+--EXPECT--
+string(4) "leaf"


### PR DESCRIPTION
## Problem

`Preprocessor::prepareClassMethod()` registers method-override flags in two directions, but neither covers the "sandwich" preprocessing order (ancestor → leaf → intermediate class):

1. **Upward marking**: when a subclass is prepared, it walks up `symbols->parent()` and marks already-registered ancestor methods as overridden — but the `isset()` guard only reaches *already-prepared* ancestors, and an unregistered link in the parent chain terminates the loop early.
2. **Downward lookup** (`isMethodOverriddenInSubClasses()`): when an ancestor is prepared, it scans subclasses — but only sees *already-prepared* subclasses.

With source order `Base → Leaf → Mid`:

- `Base` prepared (1st): downward lookup, `Leaf` not processed yet → flag stays `false`
- `Leaf` prepared (2nd): walks up, `symbols->parent('app\mid')` not registered yet (`Mid` is 3rd) → chain breaks after one step, never reaches `Base`
- `Mid` prepared (3rd): only marks upward for its own declared methods; `perform` is not among them → `Base`'s flag stays `false` forever

Later, `MethodCallTrait::findNativeMethod()` queries `isOverrideMethod('app\base::perform')`, gets `false`, and **devirtualizes the call into a direct native call** — subclass overrides never execute.

## Minimal reproduction

Four files; **the `sources` order is part of the trigger** (Leaf before Mid):

```php
<?php
// src/a.php — ancestor
namespace App;

class Base {
    protected function perform() { return 'base'; }
    public function delete() { return $this->perform(); }  // late-bound call
}
```

```php
<?php
// src/b.php — leaf (overrides the method)
namespace App;

class Leaf extends Mid {
    protected function perform() { return 'leaf'; }
}
```

```php
<?php
// src/c.php — intermediate (the "sandwich" middle layer)
namespace App;

class Mid extends Base {}
```

```php
<?php
// src/entry.php
function main(int $argc, array $argv): void {
    echo (new \App\Leaf())->delete(), "\n";
}
```

```yaml
# typephp.yml — note the order: b.php (leaf) before c.php (intermediate)
name: order-test
build-mode: bin
version: 0.1.0
output: build/order-test
build-dir: build/typephp
no-progress: true
sources:
  - ./src/entry.php
  - ./src/a.php
  - ./src/b.php
  - ./src/c.php
```

**Actual:** prints `base` — `Leaf::perform()` is ignored. In the generated C++, the `perform()` call inside `Base::delete()` is devirtualized to a direct native call (`php_app__base__perform(this_)`).

**Expected (Zend parity):** prints `leaf`.

Control experiment (both verified): swapping only the order of b/c flips the result — `a → b → c` ❌ prints `base`, `a → c → b` ✅ prints `leaf`.

## Real-world impact

Hit in a real Hyperf project, and it is a **data-correctness bug**: `Hyperf\Database\Model\SoftDeletes::performDeleteOnModel()` overrides the same-named base `Model` method to implement soft deletes. After the faulty devirtualization, `delete()` calls the base implementation directly, so **soft-deletable models are physically deleted** (`delete from ... where id = ?` instead of `update deleted_at`). The same pattern exists in `Hyperf\ModelCache\Cacheable` (overrides `query()`/`newQuery()`/`increment()` etc., silently disabling the cache) and `Hyperf\DbConnection\Traits\HasContainer` (overrides `getConnection()`).

In the real project the trigger order came from directory alphabetical order: `app/Model/Branch.php` (B) is prepared before `app/Model/Model.php` (M), while the vendor ancestor classes precede the whole `app/` tree — exactly the sandwich.

## Fix

After all files are prepared and before conversion starts, recompute the override flags once against the complete inheritance graph (idempotent, +29 lines). With the patch, the reproduction prints `leaf`, and the full Hyperf project passes end-to-end smoke tests (soft delete writes `deleted_at` correctly; login/list endpoints all OK).

## Environment

- TypePHP Compiler (AOT) v0.6.8 (HEAD 7bdb6dcd)
- libphp: PHP 8.4.24 NTS
- OS: WSL2 Ubuntu x86_64
