### PR TITLE
fix(optimizer): handle internal class literals in get_parent_class

### DIFF
--- a/phpunit/code/get-parent-class-internal-literal.php
+++ b/phpunit/code/get-parent-class-internal-literal.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+function getParentClassInternalLiteral(): void
+{
+    var_dump(get_parent_class('RuntimeException'));
+    var_dump(get_parent_class('Exception'));
+}

--- a/phpunit/src/GetParentClassOptimizerTest.php
+++ b/phpunit/src/GetParentClassOptimizerTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+namespace TypePhp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use TypePhp\CompilerTest;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+final class GetParentClassOptimizerTest extends TestCase
+{
+    public function testInternalClassLiteralFallsBackToRuntimeLookup(): void
+    {
+        global $translator;
+
+        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+        $translator = $compiler;
+        $source = TYPEPHP_ROOT_PATH . '/phpunit/code/get-parent-class-internal-literal.php';
+        $compiler->addFiles([$source]);
+        $compiler->prepareFile($source);
+        $cpp = file_get_contents($compiler->convertFile($source));
+
+        self::assertIsString($cpp);
+        self::assertSame(2, substr_count($cpp, 'php::fn::get_parent_class('));
+    }
+}

--- a/src/Optimizer/FuncCallOptimizer.php
+++ b/src/Optimizer/FuncCallOptimizer.php
@@ -965,7 +965,7 @@ trait FuncCallOptimizer
             );
         }
         if ($this->isScalarString($arg)) {
-            $cls = $this->getClass($arg->value);
+            $cls = $this->getClassDef($arg->value);
             if ($cls && $cls->extends) return $this->getLiteralString($cls->extends);
             if ($cls && !$cls->extends) return 'false';
         }

--- a/tests/std/core/006_get_parent_class.phpt
+++ b/tests/std/core/006_get_parent_class.phpt
@@ -16,6 +16,8 @@ function main() {
     echo get_parent_class(Child::class) === "Base" ? "ok-cls\n" : "fail-cls\n";
     echo get_parent_class($noParent) === false ? "ok-obj-false\n" : "fail-obj-false\n";
     echo get_parent_class(NoParent::class) === false ? "ok-cls-false\n" : "fail-cls-false\n";
+    echo get_parent_class('RuntimeException') === "Exception" ? "ok-internal-cls\n" : "fail-internal-cls\n";
+    echo get_parent_class('Exception') === false ? "ok-internal-cls-false\n" : "fail-internal-cls-false\n";
 
     echo "done\n";
 }
@@ -26,4 +28,6 @@ ok-obj
 ok-cls
 ok-obj-false
 ok-cls-false
+ok-internal-cls
+ok-internal-cls-false
 done


### PR DESCRIPTION
## Problem

`get_parent_class()` crashes during conversion when a string literal names an internal PHP class:

```php
get_parent_class('RuntimeException');
```

The optimizer assumes every literal class name exists in the compilation symbol table and uses the non-null lookup, so internal classes produce an invalid lookup instead of falling back to runtime resolution.

## Fix

Use the nullable class lookup for compile-time folding. Known project classes continue to fold at compile time, while internal class names use `php::fn::get_parent_class()`.

## Tests

- Added focused code-generation coverage for internal class literals.
- Extended `get_parent_class()` PHPT coverage for internal classes with and without parents.
- Verified the PHPUnit, PHPT, and platform build workflows on PHP 8.4 and PHP 8.5.