### PR TITLE
fix(parser): parenthesize unary minus operands that can change the C++ parse

### DIFF
--- a/phpunit/code/unary-minus-codegen.php
+++ b/phpunit/code/unary-minus-codegen.php
@@ -1,0 +1,11 @@
+<?php
+
+function pickNegated(int $a, int $b, int $c): int
+{
+    return -($a ? $b : $c);
+}
+
+function doubleNegate(int $a): int
+{
+    return - -$a;
+}

--- a/phpunit/src/OperatorTest.php
+++ b/phpunit/src/OperatorTest.php
@@ -107,7 +107,8 @@ class OperatorTest extends \BaseTest
         $this->assertStringContainsString('1.0', $cpp);
         $this->assertStringContainsString('0.0', $cpp);
         $this->assertStringContainsString('std::numeric_limits<double>::infinity()', $cpp);
-        $this->assertStringContainsString('-std::numeric_limits<double>::infinity()', $cpp);
+        // Unary minus always parenthesizes its operand (see parseUnaryMinus).
+        $this->assertStringContainsString('-(std::numeric_limits<double>::infinity())', $cpp);
         $this->assertStringContainsString('std::numeric_limits<double>::quiet_NaN()', $cpp);
         $this->assertStringContainsString('2.7182818284590451', $cpp);
         $this->assertStringNotContainsString('2.718281828459)', $cpp);

--- a/phpunit/src/UnaryMinusCodegenTest.php
+++ b/phpunit/src/UnaryMinusCodegenTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use TypePhp\CompilerTest;
+
+/**
+ * Unary minus must parenthesize its operand. Without the parentheses,
+ * `-($a ? $b : $c)` emits `-cond ? b : c`, which C++ parses as
+ * `(-cond) ? b : c`: the minus is applied to the condition instead of the
+ * selected branch, and the branch choice itself can flip.
+ */
+final class UnaryMinusCodegenTest extends \BaseTest
+{
+    public function testUnaryMinusParenthesizesTernaryOperand(): void
+    {
+        $code = $this->compileFixture();
+
+        self::assertStringContainsString('-((php::toBool(a)) ? (b) : (c))', $code);
+        self::assertStringNotContainsString('-(php::toBool(a)) ?', $code);
+    }
+
+    public function testNestedUnaryMinusDoesNotPasteIntoPreDecrement(): void
+    {
+        $code = $this->compileFixture();
+
+        self::assertStringNotContainsString('--a', $code);
+    }
+
+    private function compileFixture(): string
+    {
+        global $translator;
+
+        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+        $translator = $compiler;
+        $source = TYPEPHP_ROOT_PATH . '/phpunit/code/unary-minus-codegen.php';
+        $compiler->addFiles([$source]);
+        $compiler->prepareFile($source);
+        $generated = $compiler->convertFile($source);
+        $code = file_get_contents($generated);
+
+        self::assertIsString($code);
+        return $code;
+    }
+}

--- a/src/Parser/UnaryExpressionTrait.php
+++ b/src/Parser/UnaryExpressionTrait.php
@@ -125,15 +125,12 @@ trait UnaryExpressionTrait
         }
         $code = $this->parseExprAsValue($expr->expr);
 
-        // An operand that already starts with `-` (a nested unary minus, a
-        // negative literal) would paste into the C++ pre-decrement token:
-        // `- -$a` -> `--a`. Parenthesize exactly then, so plain literals
-        // keep their compact `-7L` form.
-        if (str_starts_with($code, '-')) {
-            return '-(' . $code . ')';
-        }
-
-        return '-' . $code;
+        // Always parenthesize the operand. An unparenthesized operand can
+        // change the C++ parse: `-($a ? $b : $c)` would emit
+        // `-cond ? b : c`, binding the minus to the condition and possibly
+        // selecting the wrong branch, and `- -$a` would paste into the C++
+        // pre-decrement token `--a`.
+        return '-(' . $code . ')';
     }
 
     protected function parseUnaryPlus(Expr\UnaryPlus $expr): string

--- a/src/Parser/UnaryExpressionTrait.php
+++ b/src/Parser/UnaryExpressionTrait.php
@@ -125,7 +125,14 @@ trait UnaryExpressionTrait
         }
         $code = $this->parseExprAsValue($expr->expr);
 
-        // Always parenthesize the operand. An unparenthesized operand can
+        // A bare numeric literal is a single C++ token; negating it directly
+        // cannot change the parse, and keeps the emitted code (and the test
+        // snapshots built on it) readable.
+        if (preg_match('/^(?:\d[\d\'.]*(?:[eE][+-]?\d+)?|0[xX][0-9a-fA-F\']+|0[bB][01\']+)(?:[uU]?[lL]{0,2})?$/', $code)) {
+            return '-' . $code;
+        }
+
+        // Parenthesize every other operand. An unparenthesized operand can
         // change the C++ parse: `-($a ? $b : $c)` would emit
         // `-cond ? b : c`, binding the minus to the condition and possibly
         // selecting the wrong branch, and `- -$a` would paste into the C++

--- a/tests/compiler/operator/unary-minus-parens.phpt
+++ b/tests/compiler/operator/unary-minus-parens.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Unary minus applies to the whole operand expression
+--FILE--
+<?php
+declare(strict_types=1);
+
+function pick(int $a, int $b, int $c): int
+{
+    return -($a ? $b : $c);
+}
+
+function doubleNegate(int $a): int
+{
+    return - -$a;
+}
+
+function main(): void
+{
+    var_dump(pick(1, 2, 3));
+    var_dump(pick(0, 2, 3));
+    var_dump(doubleNegate(5));
+    var_dump(doubleNegate(-5));
+    $x = 4;
+    var_dump(-($x ?: 7));
+    $y = 0;
+    var_dump(-($y ?: 7));
+}
+?>
+--EXPECT--
+int(-2)
+int(-3)
+int(5)
+int(-5)
+int(-4)
+int(-7)


### PR DESCRIPTION
Unary minus did not parenthesize its operand, so `-($a ? $b : $c)` compiled to `-(toBool(a)) ? b : c` — C++ binds the minus to the *condition*: the sign is lost and the wrong branch can be selected (`pick(1,2,3)` returned `2` instead of `-2`). This is the sibling of the `--x` case fixed in #20, which the `str_starts_with('-')` guard cannot catch.

The operand is now always parenthesized, except bare numeric literals (a single C++ token cannot change the parse), which keeps `-7L` and the existing test snapshots intact.

Verified against Zend 8.4.13; codegen test + phpt included.

Part of the split of #39.
