### PR TITLE
fix(gen_stub): spell PHP_INT_MIN constants with ZEND_LONG_MIN

### DIFF
--- a/phpunit/code/int-min-constant-metadata.php
+++ b/phpunit/code/int-min-constant-metadata.php
@@ -1,0 +1,16 @@
+<?php
+
+class IntMinConstants
+{
+    const MIN = PHP_INT_MIN;
+    const MAX = PHP_INT_MAX;
+    const NEGZ = -0.0;
+    const PI = M_PI;
+
+    public int $floor = PHP_INT_MIN;
+}
+
+function useIntMinDefault(int $x = PHP_INT_MIN): int
+{
+    return $x;
+}

--- a/phpunit/src/ConstantMetadataLiteralTest.php
+++ b/phpunit/src/ConstantMetadataLiteralTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use TypePhp\CompilerTest;
+
+/**
+ * Class-constant and property-default metadata must embed scalar values with
+ * exact, well-formed C literals: PHP_INT_MIN cannot be spelled as one
+ * negative literal ("-9223372036854775808" negates an out-of-range positive
+ * literal and is ill-formed), -0.0 must keep its sign, and doubles must
+ * round-trip at 17 significant digits.
+ */
+final class ConstantMetadataLiteralTest extends \BaseTest
+{
+    public function testIntMinAndFloatConstantsEmitExactLiterals(): void
+    {
+        $previous = ini_set('precision', '14');
+        try {
+            global $translator;
+            $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+            $translator = $compiler;
+            $testFile = TYPEPHP_ROOT_PATH . '/phpunit/code/int-min-constant-metadata.php';
+            $compiler->addFiles([$testFile]);
+            $compiler->prepareFile($testFile);
+            $compiler->convertFile($testFile);
+            $arginfoHeader = $compiler->getArgInfoHeaderFile($testFile);
+            $arginfo = file_get_contents($arginfoHeader);
+        } finally {
+            if ($previous !== false) {
+                ini_set('precision', $previous);
+            }
+        }
+
+        self::assertIsString($arginfo);
+        self::assertStringContainsString('ZVAL_LONG(&const_MIN_value, ZEND_LONG_MIN);', $arginfo);
+        self::assertStringContainsString('ZVAL_LONG(&const_MAX_value, 9223372036854775807);', $arginfo);
+        self::assertStringContainsString('ZVAL_LONG(&property_floor_default_value, ZEND_LONG_MIN);', $arginfo);
+        self::assertStringContainsString('ZVAL_DOUBLE(&const_NEGZ_value, -0.0);', $arginfo);
+        self::assertStringContainsString('ZVAL_DOUBLE(&const_PI_value, 3.1415926535897931);', $arginfo);
+        self::assertStringNotContainsString('-9223372036854775808', $arginfo);
+    }
+}

--- a/src/gen_stub.php
+++ b/src/gen_stub.php
@@ -2828,6 +2828,13 @@ class EvaluatedValue
             // leaking heredoc/nowdoc source syntax into generated C++.
             return '"' . getTranslator()->escapeString((string) $this->value) . '"';
         } elseif ($this->type->isInt()) {
+            // PHP_INT_MIN cannot be spelled as one negative literal: C parses
+            // "-9223372036854775808" as negation applied to an out-of-range
+            // positive literal, which is ill-formed. Reuse the ZEND_LONG_MIN
+            // macro, exactly like the expression path (genIntegerLiteral).
+            if ($this->value === PHP_INT_MIN) {
+                return 'ZEND_LONG_MIN';
+            }
             return strval($this->value);
         } elseif ($this->type->isFloat()) {
             return getTranslator()->genFloatLiteral((float) $this->value);


### PR DESCRIPTION
`const M = PHP_INT_MIN;` (and property/parameter defaults with that value) made gen_stub emit `ZVAL_LONG(&v, -9223372036854775808)` — an ill-formed C literal (`9223372036854775808` overflows long long before negation; clang warns, breaks under -Werror). The compiler's own genIntegerLiteral already spells this `ZEND_LONG_MIN`; getCExpr() now does the same.

Test pins the exact emitted literals.

Part of the split of #39.
