### PR TITLE
fix(translator): allow overrides to add a by-ref return

### DIFF
--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -5,6 +5,21 @@ use TypePhp\CompilerTest;
 use TypePhp\Exception\TestError;
 
 require __DIR__ . '/../bin/bootstrap.php';
+
+// The vendor directory may be shared between checkouts (e.g. a git worktree
+// with a symlinked vendor/). Composer's autoloader resolves TypePhp\ against
+// the checkout that owns vendor/, which would silently test another tree's
+// sources. Prepend a loader anchored to THIS checkout so the test suite always
+// exercises the code it ships with.
+spl_autoload_register(static function (string $class): void {
+    if (str_starts_with($class, 'TypePhp\\')) {
+        $path = dirname(__DIR__) . '/src/' . str_replace('\\', '/', substr($class, strlen('TypePhp\\'))) . '.php';
+        if (is_file($path)) {
+            require $path;
+        }
+    }
+}, true, true);
+
 require_once __DIR__ . '/../src/polyfills.php';
 require __DIR__ . '/../src/gen_stub.php';
 

--- a/phpunit/code/override_byref_return_added.php
+++ b/phpunit/code/override_byref_return_added.php
@@ -1,0 +1,19 @@
+<?php
+class A
+{
+    public function f(): array
+    {
+        return [];
+    }
+}
+
+class B extends A
+{
+    public function &f(): array
+    {
+        static $a = [];
+        return $a;
+    }
+}
+
+function main() {}

--- a/phpunit/code/override_byref_return_dropped.php
+++ b/phpunit/code/override_byref_return_dropped.php
@@ -1,0 +1,19 @@
+<?php
+class A
+{
+    public function &f(): array
+    {
+        static $a = [];
+        return $a;
+    }
+}
+
+class B extends A
+{
+    public function f(): array
+    {
+        return [];
+    }
+}
+
+function main() {}

--- a/phpunit/src/MethodOverrideByRefReturnTest.php
+++ b/phpunit/src/MethodOverrideByRefReturnTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use TypePhp\Exception\TestError;
+
+/**
+ * Zend treats by-ref returns as covariant in overrides: a child method may add
+ * `&` to its return (callers expecting a value still work), but it must not
+ * drop a by-ref return promised by the parent contract.
+ */
+class MethodOverrideByRefReturnTest extends BaseTest
+{
+    public function testOverrideMayAddByRefReturn(): void
+    {
+        $this->compile('override_byref_return_added.php');
+    }
+
+    public function testOverrideCannotDropByRefReturn(): void
+    {
+        $this->exec(
+            'Declaration of `B::f()` must be compatible with `A::f()`',
+            'override_byref_return_dropped.php',
+        );
+    }
+}

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -4674,7 +4674,10 @@ CODE;
         )) {
             $this->fatalMethodOverrideIncompatible($v, $className, $methodName, $parentClass);
         }
-        if ($childFuncDef->returnsByRef !== $parentFuncDef->returnsByRef) {
+        // Zend treats by-ref returns as covariant: an override may add `&`
+        // (callers expecting a value still work), but it must not drop one
+        // promised by the parent contract.
+        if ($parentFuncDef->returnsByRef && !$childFuncDef->returnsByRef) {
             $this->fatalMethodOverrideIncompatible($v, $className, $methodName, $parentClass);
         }
 


### PR DESCRIPTION
Adding a by-ref return in an override was rejected: `class B extends A { public function &f(): array {...} }` over a plain `f(): array` failed "must be compatible", while Zend only forbids *dropping* a by-ref promised by the parent (that direction stays rejected).

The exact-equality check becomes one-directional. Also includes a small test-infra commit anchoring phpunit's TypePhp autoloading to the current checkout (protects suites run from worktrees with a shared vendor/; a no-op in a standalone checkout).

Verified against Zend 8.4.13; tests both directions.

Part of the split of #39.
