### PR TITLE
fix(translator): let a trailing child variadic absorb parent parameters

### DIFF
--- a/phpunit/code/override_parent_variadic_child_extra.php
+++ b/phpunit/code/override_parent_variadic_child_extra.php
@@ -1,0 +1,12 @@
+<?php
+class A
+{
+    public function f(int ...$args): void {}
+}
+
+class B extends A
+{
+    public function f(int $a = 1, int ...$rest): void {}
+}
+
+function main() {}

--- a/phpunit/code/override_parent_variadic_child_not.php
+++ b/phpunit/code/override_parent_variadic_child_not.php
@@ -1,0 +1,12 @@
+<?php
+class A
+{
+    public function f(int ...$args): void {}
+}
+
+class B extends A
+{
+    public function f(int $a = 0): void {}
+}
+
+function main() {}

--- a/phpunit/code/override_variadic_absorbs_params.php
+++ b/phpunit/code/override_variadic_absorbs_params.php
@@ -1,0 +1,26 @@
+<?php
+class A
+{
+    public function f(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}
+
+class B extends A
+{
+    public function f(int ...$args): int
+    {
+        return 0;
+    }
+}
+
+class C extends A
+{
+    public function f(int $a, int ...$rest): int
+    {
+        return $a;
+    }
+}
+
+function main() {}

--- a/phpunit/code/override_variadic_bad_type.php
+++ b/phpunit/code/override_variadic_bad_type.php
@@ -1,0 +1,12 @@
+<?php
+class A
+{
+    public function f(int $a, string $b): void {}
+}
+
+class B extends A
+{
+    public function f(int ...$args): void {}
+}
+
+function main() {}

--- a/phpunit/code/override_variadic_byref_mismatch.php
+++ b/phpunit/code/override_variadic_byref_mismatch.php
@@ -1,0 +1,12 @@
+<?php
+class A
+{
+    public function f(int &$a): void {}
+}
+
+class B extends A
+{
+    public function f(int ...$args): void {}
+}
+
+function main() {}

--- a/phpunit/src/InheritanceErrorTest.php
+++ b/phpunit/src/InheritanceErrorTest.php
@@ -113,9 +113,11 @@ class InheritanceErrorTest extends TestCase
         $this->exec('must be compatible', 'inheritance_error_byref.php');
     }
 
-    public function testVariadicMismatch()
+    public function testTrailingVariadicMayAbsorbParentParameter()
     {
-        $this->exec('must be compatible', 'inheritance_error_variadic.php');
+        // Zend accepts a trailing child variadic standing in for the remaining
+        // parent parameter positions (zend_do_perform_implementation_check).
+        $this->assertCompiles('inheritance_error_variadic.php');
     }
 
     public function testMethodVisibilityMismatch()

--- a/phpunit/src/MethodOverrideVariadicTest.php
+++ b/phpunit/src/MethodOverrideVariadicTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use TypePhp\Exception\TestError;
+
+/**
+ * Zend's inheritance check lets a trailing child variadic stand in for every
+ * remaining parent parameter position (the decorator pattern), provided the
+ * variadic's type is contravariant-compatible with each covered position and
+ * by-ref-ness matches. A variadic parent still requires a variadic child, and
+ * when the parent is variadic every extra child parameter is validated against
+ * the parent's variadic slot.
+ */
+class MethodOverrideVariadicTest extends BaseTest
+{
+    public function testTrailingChildVariadicAbsorbsParentParameters(): void
+    {
+        $this->compile('override_variadic_absorbs_params.php');
+    }
+
+    public function testChildVariadicTypeMustCoverEveryAbsorbedPosition(): void
+    {
+        $this->exec(
+            'Declaration of `B::f()` must be compatible with `A::f()`',
+            'override_variadic_bad_type.php',
+        );
+    }
+
+    public function testChildVariadicMustMatchByRefOfAbsorbedPosition(): void
+    {
+        $this->exec(
+            'Declaration of `B::f()` must be compatible with `A::f()`',
+            'override_variadic_byref_mismatch.php',
+        );
+    }
+
+    public function testVariadicParentRequiresVariadicChild(): void
+    {
+        $this->exec(
+            'Declaration of `B::f()` must be compatible with `A::f()`',
+            'override_parent_variadic_child_not.php',
+        );
+    }
+
+    public function testExtraChildParametersCheckedAgainstParentVariadic(): void
+    {
+        $this->compile('override_parent_variadic_child_extra.php');
+    }
+}

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -4684,12 +4684,33 @@ CODE;
             $this->fatalMethodOverrideIncompatible($v, $className, $methodName, $parentClass);
         }
 
-        // Compare each parent-declared parameter position.
-        foreach ($parentFuncDef->argInfoList as $i => $parentArg) {
-            if (!isset($childFuncDef->argInfoList[$i])) {
-                $this->fatalMethodOverrideIncompatible($v, $className, $methodName, $parentClass);
+        // A variadic parent accepts unbounded arguments, so Zend requires the
+        // override to be variadic as well.
+        $parentVariadic = $parentFuncDef->hasVariadicArg();
+        $childVariadic = $childFuncDef->hasVariadicArg();
+        if ($parentVariadic && !$childVariadic) {
+            $this->fatalMethodOverrideIncompatible($v, $className, $methodName, $parentClass);
+        }
+
+        // Compare each parent-declared parameter position. Following Zend's
+        // inheritance check, a trailing child variadic stands in for every
+        // remaining parent position (the decorator pattern), and when the
+        // parent is variadic each extra child parameter is validated against
+        // the parent's variadic slot.
+        $positions = count($parentFuncDef->argInfoList);
+        if ($parentVariadic) {
+            $positions = max($positions, count($childFuncDef->argInfoList));
+        }
+        for ($i = 0; $i < $positions; $i++) {
+            $parentArg = $parentFuncDef->argInfoList[$i]
+                ?? $parentFuncDef->argInfoList[count($parentFuncDef->argInfoList) - 1];
+            $childArg = $childFuncDef->argInfoList[$i] ?? null;
+            if ($childArg === null) {
+                if (!$childVariadic) {
+                    $this->fatalMethodOverrideIncompatible($v, $className, $methodName, $parentClass);
+                }
+                $childArg = $childFuncDef->argInfoList[count($childFuncDef->argInfoList) - 1];
             }
-            $childArg = $childFuncDef->argInfoList[$i];
             if ($parentArg->immutable && !$childArg->immutable) {
                 $this->fatalMethodOverrideIncompatible($v, $className, $methodName, $parentClass);
             }
@@ -4697,9 +4718,6 @@ CODE;
                 $this->fatalMethodOverrideIncompatible($v, $className, $methodName, $parentClass);
             }
             if ($childArg->byRef !== $parentArg->byRef) {
-                $this->fatalMethodOverrideIncompatible($v, $className, $methodName, $parentClass);
-            }
-            if ($childArg->variadic !== $parentArg->variadic) {
                 $this->fatalMethodOverrideIncompatible($v, $className, $methodName, $parentClass);
             }
         }


### PR DESCRIPTION
A trailing child variadic absorbing parent parameters was rejected: parent `f(int $a, int $b)`, child `f(int ...$args)` failed "must be compatible", breaking the common decorator/proxy pattern (Zend accepts it). The per-position loop required exact variadic equality at each index.

The loop now follows Zend's rules: a variadic parent requires a variadic child; a trailing child variadic covers every remaining parent position (contravariant type, matching by-ref-ness per position); extra child parameters must stay optional. The pre-existing testVariadicMismatch encoded the rejects-valid behavior (verified against Zend) and was updated to assert compilation.

Verified against Zend 8.4.13, 11-case probe matrix.

Part of the split of #39.
