### PR TITLE
fix(translator): constructor, private-method and abstract redeclaration override rules

### DIFF
--- a/phpunit/code/abstract_redeclare_concrete.php
+++ b/phpunit/code/abstract_redeclare_concrete.php
@@ -1,0 +1,5 @@
+<?php
+class A { public function f(): int { return 1; } }
+abstract class B extends A { abstract public function f(): int; }
+
+function main() {}

--- a/phpunit/code/abstract_redeclare_incompatible.php
+++ b/phpunit/code/abstract_redeclare_incompatible.php
@@ -1,0 +1,5 @@
+<?php
+abstract class A { abstract public function f(): int; }
+abstract class B extends A { abstract public function f(): string; }
+
+function main() {}

--- a/phpunit/code/abstract_redeclare_internal.php
+++ b/phpunit/code/abstract_redeclare_internal.php
@@ -1,0 +1,4 @@
+<?php
+abstract class B extends ArrayObject { abstract public function count(): int; }
+
+function main() {}

--- a/phpunit/code/abstract_redeclare_valid.php
+++ b/phpunit/code/abstract_redeclare_valid.php
@@ -1,0 +1,15 @@
+<?php
+// Redeclaring an inherited abstract contract compatibly is legal, a parent's
+// private method is not inherited, and a trait's abstract requirement may be
+// satisfied by an inherited concrete method.
+abstract class A { abstract public function f(): int; }
+abstract class B extends A { abstract public function f(): int; }
+
+class C { private function g(): int { return 1; } }
+abstract class D extends C { abstract public function g(): int; }
+
+trait RequiresF { abstract public function h(): int; }
+class E { public function h(): int { return 1; } }
+class F extends E { use RequiresF; }
+
+function main() {}

--- a/phpunit/code/ctor_override_abstract_incompatible.php
+++ b/phpunit/code/ctor_override_abstract_incompatible.php
@@ -1,0 +1,12 @@
+<?php
+abstract class A
+{
+    abstract public function __construct(int $x);
+}
+
+class B extends A
+{
+    public function __construct(string $x) {}
+}
+
+function main() {}

--- a/phpunit/code/ctor_override_final.php
+++ b/phpunit/code/ctor_override_final.php
@@ -1,0 +1,12 @@
+<?php
+class A
+{
+    final public function __construct() {}
+}
+
+class B extends A
+{
+    public function __construct() {}
+}
+
+function main() {}

--- a/phpunit/code/ctor_override_final_private.php
+++ b/phpunit/code/ctor_override_final_private.php
@@ -1,0 +1,12 @@
+<?php
+class A
+{
+    final private function __construct() {}
+}
+
+class B extends A
+{
+    public function __construct() {}
+}
+
+function main() {}

--- a/phpunit/code/ctor_override_valid.php
+++ b/phpunit/code/ctor_override_valid.php
@@ -1,0 +1,39 @@
+<?php
+class A
+{
+    public function __construct(int $x) {}
+}
+
+// A concrete parent constructor imposes no signature contract: the child may
+// change the parameters and even narrow visibility.
+class B extends A
+{
+    private function __construct(string $y, array $z)
+    {
+        parent::__construct(1);
+    }
+}
+
+class C
+{
+    private function __construct(int $x) {}
+}
+
+// A private parent constructor may be redeclared freely.
+class D extends C
+{
+    public function __construct(string $y) {}
+}
+
+abstract class E
+{
+    abstract public function __construct(int $x);
+}
+
+// Adding optional trailing parameters satisfies an abstract constructor.
+class F extends E
+{
+    public function __construct(int $x, string $y = '') {}
+}
+
+function main() {}

--- a/phpunit/code/private_redeclare_valid.php
+++ b/phpunit/code/private_redeclare_valid.php
@@ -1,0 +1,53 @@
+<?php
+class A
+{
+    private function helper(): string
+    {
+        return 'A';
+    }
+
+    public function run(): string
+    {
+        // Binds A::helper() even on a B instance (private-scope binding).
+        return $this->helper();
+    }
+}
+
+class B extends A
+{
+    // Any signature is allowed: private methods are not inherited.
+    public function helper(int $n = 0): int
+    {
+        return $n;
+    }
+}
+
+class C
+{
+    final private function locked(): void {}
+}
+
+// Zend ignores FINAL on non-constructor private methods (declaring one only
+// warns), so a child may still redeclare it.
+class D extends C
+{
+    public function locked(): void {}
+}
+
+class E
+{
+    private static function make(): int
+    {
+        return 1;
+    }
+}
+
+class F extends E
+{
+    public static function make(): string
+    {
+        return 'f';
+    }
+}
+
+function main() {}

--- a/phpunit/src/AbstractRedeclarationTest.php
+++ b/phpunit/src/AbstractRedeclarationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * An abstract method declared by the class itself participates in the parent
+ * checks: it cannot turn a concrete inherited method abstract, and it must
+ * stay compatible with an inherited abstract contract. Trait requirements are
+ * exempt (an inherited concrete method satisfies them).
+ */
+class AbstractRedeclarationTest extends BaseTest
+{
+    public function testConcreteParentMethodCannotBeMadeAbstract(): void
+    {
+        $this->exec(
+            'Cannot make non abstract method `A::f()` abstract in class `B`',
+            'abstract_redeclare_concrete.php'
+        );
+    }
+
+    public function testAbstractRedeclarationMustStayCompatible(): void
+    {
+        $this->exec(
+            'Declaration of `B::f()` must be compatible with `A::f()`',
+            'abstract_redeclare_incompatible.php'
+        );
+    }
+
+    public function testConcreteBuiltinMethodCannotBeMadeAbstract(): void
+    {
+        $this->exec(
+            'Cannot make non abstract method `ArrayObject::count()` abstract in class `B`',
+            'abstract_redeclare_internal.php'
+        );
+    }
+
+    public function testValidAbstractRedeclarations(): void
+    {
+        $this->compile('abstract_redeclare_valid.php');
+    }
+}

--- a/phpunit/src/ClassTest.php
+++ b/phpunit/src/ClassTest.php
@@ -730,9 +730,12 @@ class ClassTest extends \BaseTest
         $this->exec('abstract class `AbstractBase` cannot be instantiated', 'abstract-class-new.php');
     }
 
-    public function testOverridePrivateMethod()
+    public function testPrivateMethodMayBeRedeclared()
     {
-        $this->exec('Cannot override private method `Base::doWork()`', 'override-private-method.php');
+        // Private methods are not inherited: Zend lets a child redeclare one
+        // with any signature. Private calls bind to the declaring class's
+        // copy, so each class keeps its own implementation.
+        $this->compile('override-private-method.php');
     }
 
     public function testPromotedAsymmetricPropertyRequiresType(): void
@@ -776,12 +779,11 @@ class ClassTest extends \BaseTest
         $this->exec('Cannot access private method `BaseSecret::secret()`', 'trait-parent-method-private.php');
     }
 
-    public function testComposedTraitMethodCannotShadowPrivateParentMethod()
+    public function testComposedTraitMethodMayShadowPrivateParentMethod()
     {
-        $this->exec(
-            'Cannot override private method `PrivateMethodParent::execute()`',
-            'trait-method-shadows-private.php'
-        );
+        // A trait-composed method redeclaring a parent's PRIVATE method is
+        // valid in Zend, like any other private redeclaration.
+        $this->compile('trait-method-shadows-private.php');
     }
 
     public function testSelfCanBePartOfUnionType()

--- a/phpunit/src/ConstructorOverrideTest.php
+++ b/phpunit/src/ConstructorOverrideTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use TypePhp\Exception\TestError;
+
+/**
+ * Zend exempts constructors from LSP checks against a CONCRETE parent
+ * constructor, but still forbids overriding a FINAL parent constructor (even a
+ * final private one), and validates the signature against an ABSTRACT parent
+ * constructor exactly like an interface constructor.
+ */
+class ConstructorOverrideTest extends BaseTest
+{
+    public function testConcreteAndPrivateParentConstructorsAreExempt(): void
+    {
+        $this->compile('ctor_override_valid.php');
+    }
+
+    public function testFinalParentConstructorCannotBeOverridden(): void
+    {
+        $this->exec(
+            'Cannot override final method `A::__construct()`',
+            'ctor_override_final.php',
+        );
+    }
+
+    public function testFinalPrivateParentConstructorCannotBeOverridden(): void
+    {
+        $this->exec(
+            'Cannot override final method `A::__construct()`',
+            'ctor_override_final_private.php',
+        );
+    }
+
+    public function testAbstractParentConstructorSignatureIsEnforced(): void
+    {
+        $this->exec(
+            'Declaration of `B::__construct()` must be compatible with `A::__construct()`',
+            'ctor_override_abstract_incompatible.php',
+        );
+    }
+}

--- a/phpunit/src/PrivateMethodRedeclareTest.php
+++ b/phpunit/src/PrivateMethodRedeclareTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use TypePhp\Exception\TestError;
+
+/**
+ * Private methods are not inherited in Zend: a child class may redeclare one
+ * with any signature, visibility or staticness, and FINAL is ignored on
+ * non-constructor private methods. Generated code stays correct because
+ * private calls devirtualize to the declaring class's body — PHP's own
+ * private-scope binding — and Native classes give private methods no virtual
+ * slot.
+ */
+class PrivateMethodRedeclareTest extends BaseTest
+{
+    public function testPrivateMethodsMayBeRedeclaredFreely(): void
+    {
+        $this->compile('private_redeclare_valid.php');
+    }
+
+    public function testFinalPrivateConstructorIsStillProtectedFromOverride(): void
+    {
+        $this->exec(
+            'Cannot override final method `A::__construct()`',
+            'ctor_override_final_private.php',
+        );
+    }
+}

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -4553,10 +4553,15 @@ CODE;
 
     /**
      * Check whether a parent method can be overridden: private methods cannot be
-     * overridden, and the signature must be compatible.
+     * overridden, and the signature must be compatible. With $childIsAbstract,
+     * the declaration additionally may not turn a concrete inherited method
+     * abstract (Zend: "Cannot make non abstract method ... abstract").
      */
-    protected function checkParentMethodCanBeOverridden(Node\Stmt\ClassMethod $v, string $name): void
-    {
+    protected function checkParentMethodCanBeOverridden(
+        Node\Stmt\ClassMethod $v,
+        string $name,
+        bool $childIsAbstract = false
+    ): void {
         // Zend exempts constructors from the LSP checks against a CONCRETE
         // parent constructor (subclasses may freely change the construction
         // signature and even narrow its visibility). A FINAL parent
@@ -4584,6 +4589,10 @@ CODE;
                 }
                 if ($modifiers & \ReflectionMethod::IS_FINAL) {
                     goto _final_error;
+                }
+                if ($childIsAbstract && $modifiers !== null && !($modifiers & \ReflectionMethod::IS_ABSTRACT)) {
+                    $this->fatalError($v,
+                        "Cannot make non abstract method `{$extends}::{$name}()` abstract in class `{$this->getFullClassName()}`");
                 }
                 break;
             }
@@ -4615,6 +4624,10 @@ CODE;
                     $this->fatalGeneratedMethodAttributeIfAny($v, $message, $extends, $name);
                     $this->fatalError($v,
                         $message);
+                }
+                if ($childIsAbstract) {
+                    $this->fatalError($v,
+                        "Cannot make non abstract method `{$extends}::{$name}()` abstract in class `{$this->getFullClassName()}`");
                 }
                 if (!$isConstructor) {
                     $this->validateMethodOverrideSignature($v, $name, $this->methodDef, $methodDef, $extends);
@@ -5534,6 +5547,20 @@ CODE;
             // only run in the implementation phase.
             $this->checkParentMethodCanBeOverridden($v, $name);
             $methodCodes[$name] = $this->parseFunction($v);
+        } elseif ($this->classDef->trait === null
+            && !is_string($v->getAttribute(self::TRAIT_ORIGIN_ATTRIBUTE))
+            && $this->classDef->hasAbstractMethod($name)
+            && isset($this->classDef->abstractMethodDefs[strtolower($name)])
+        ) {
+            // An abstract method the class itself declares participates in
+            // the parent checks: it cannot turn a concrete inherited method
+            // abstract, and it must stay compatible with an inherited
+            // abstract contract. Abstract requirements arriving from traits
+            // are exempt — Zend lets an inherited concrete method satisfy
+            // them.
+            $this->methodDef = $this->classDef->getAbstractMethod($name);
+            $this->methodDef->node = $v;
+            $this->checkParentMethodCanBeOverridden($v, $name, childIsAbstract: true);
         }
 
         $this->resetMethod();

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -4557,9 +4557,13 @@ CODE;
      */
     protected function checkParentMethodCanBeOverridden(Node\Stmt\ClassMethod $v, string $name): void
     {
-        if ($name === '__construct') {
-            return;
-        }
+        // Zend exempts constructors from the LSP checks against a CONCRETE
+        // parent constructor (subclasses may freely change the construction
+        // signature and even narrow its visibility). A FINAL parent
+        // constructor still cannot be overridden — even a final private one —
+        // and an ABSTRACT parent constructor imposes a real signature
+        // contract, exactly like an interface constructor.
+        $isConstructor = strtolower($name) === '__construct';
 
         $classDef = $this->classDef;
         $childFuncDef = $this->methodDef->functionDef;
@@ -4571,7 +4575,7 @@ CODE;
             // The parent class is a built-in class
             if ($classDef->inheritedFromInternalClass) {
                 $modifiers = Reflection::getClassMethodModifiers($extends, $name);
-                if ($modifiers & \ReflectionMethod::IS_PRIVATE) {
+                if (!$isConstructor && ($modifiers & \ReflectionMethod::IS_PRIVATE)) {
                     goto _error;
                 }
                 if ($modifiers & \ReflectionMethod::IS_FINAL) {
@@ -4582,7 +4586,7 @@ CODE;
             $classDef = $this->getClass($extends);
             if ($classDef->hasMethod($name)) {
                 $methodDef = $classDef->getMethod($name);
-                if ($methodDef->flags & Modifiers::PRIVATE) {
+                if (!$isConstructor && ($methodDef->flags & Modifiers::PRIVATE)) {
                     _error:
                     $message = 'Cannot override private method `' . $extends . '::' . $name . '()`';
                     $this->fatalGeneratedMethodAttributeIfAny($v, $message, $extends, $name);
@@ -4606,10 +4610,14 @@ CODE;
                     $this->fatalError($v,
                         $message);
                 }
-                $this->validateMethodOverrideSignature($v, $name, $this->methodDef, $methodDef, $extends);
+                if (!$isConstructor) {
+                    $this->validateMethodOverrideSignature($v, $name, $this->methodDef, $methodDef, $extends);
+                }
                 break;
             }
             if ($classDef->hasAbstractMethod($name) && isset($classDef->abstractMethodDefs[strtolower($name)])) {
+                // An abstract parent constructor is validated like an
+                // interface constructor: its signature is a contract.
                 $this->validateMethodOverrideSignature($v, $name, $this->methodDef, $classDef->getAbstractMethod($name), $extends);
                 break;
             }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -4576,7 +4576,11 @@ CODE;
             if ($classDef->inheritedFromInternalClass) {
                 $modifiers = Reflection::getClassMethodModifiers($extends, $name);
                 if (!$isConstructor && ($modifiers & \ReflectionMethod::IS_PRIVATE)) {
-                    goto _error;
+                    // Private methods are not inherited: a child may redeclare
+                    // one with any signature. Zend ignores FINAL on private
+                    // methods outside constructors (declaring one only raises
+                    // a warning), so no final check applies here either.
+                    break;
                 }
                 if ($modifiers & \ReflectionMethod::IS_FINAL) {
                     goto _final_error;
@@ -4587,11 +4591,13 @@ CODE;
             if ($classDef->hasMethod($name)) {
                 $methodDef = $classDef->getMethod($name);
                 if (!$isConstructor && ($methodDef->flags & Modifiers::PRIVATE)) {
-                    _error:
-                    $message = 'Cannot override private method `' . $extends . '::' . $name . '()`';
-                    $this->fatalGeneratedMethodAttributeIfAny($v, $message, $extends, $name);
-                    $this->fatalError($v,
-                        $message);
+                    // See the internal-parent branch above: a private method
+                    // may be redeclared freely. Generated code stays correct
+                    // because private calls are devirtualized to the declaring
+                    // class's body (canDevirtualize()), matching PHP's
+                    // private-scope binding, and Native classes never give
+                    // private methods a virtual slot (isNativeVirtualMethod()).
+                    break;
                 }
                 if ($methodDef->flags & Modifiers::FINAL) {
                     _final_error:


### PR DESCRIPTION
Three gaps in the parent-method override checks, all in checkParentMethodCanBeOverridden:

- `__construct` overrides skipped every check via an early return — including `final` parent constructors (Zend: "Cannot override final method A::__construct()") and abstract-constructor signature contracts. Ordinary concrete parent constructors remain exempt from LSP variance, as in Zend (even visibility narrowing is legal there — probed).
- Redeclaring a parent's *private* method was rejected, but private methods are not inherited in PHP: any signature is legal. Verified safe for this compiler's dispatch before changing: private-resolved calls devirtualize to the declaring class's body (canDevirtualize), matching PHP's private-scope binding, and Native classes give private methods no virtual slot. Two pre-existing tests encoded the rejects-valid behavior (both run under Zend) and were updated.
- Abstract method redeclarations were never validated: turning a concrete inherited method abstract compiled (Zend: "Cannot make non abstract method A::f() abstract in class B") and abstract-over-abstract redeclarations skipped the signature check. Trait-originated abstract requirements stay exempt — Zend lets an inherited concrete method satisfy them (probed).

Verified against Zend 8.4.13 for every rule and direction.

Part of the split of #39.
