### PR TITLE
fix(translator): reject static/instance property redeclaration mismatch

### DIFF
--- a/phpunit/code/property_nonstatic_mismatch.php
+++ b/phpunit/code/property_nonstatic_mismatch.php
@@ -1,0 +1,12 @@
+<?php
+class A
+{
+    public int $x = 1;
+}
+
+class B extends A
+{
+    public static int $x = 2;
+}
+
+function main() {}

--- a/phpunit/code/property_static_match.php
+++ b/phpunit/code/property_static_match.php
@@ -1,0 +1,14 @@
+<?php
+class A
+{
+    public static int $x = 1;
+    public int $y = 1;
+}
+
+class B extends A
+{
+    public static int $x = 2;
+    public int $y = 2;
+}
+
+function main() {}

--- a/phpunit/code/property_static_mismatch.php
+++ b/phpunit/code/property_static_mismatch.php
@@ -1,0 +1,12 @@
+<?php
+class A
+{
+    public static int $x = 1;
+}
+
+class B extends A
+{
+    public int $x = 2;
+}
+
+function main() {}

--- a/phpunit/src/StaticPropertyOverrideTest.php
+++ b/phpunit/src/StaticPropertyOverrideTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use TypePhp\Exception\TestError;
+
+/**
+ * A static property and an instance property are different kinds of storage;
+ * Zend forbids redeclaring one as the other in either direction ("Cannot
+ * redeclare static A::$x as non static B::$x" and vice versa).
+ */
+class StaticPropertyOverrideTest extends BaseTest
+{
+    public function testMatchingStaticnessCompiles(): void
+    {
+        $this->compile('property_static_match.php');
+    }
+
+    public function testStaticCannotBecomeInstance(): void
+    {
+        $this->exec(
+            'Cannot redeclare static `A::$x` as non static `B::$x`',
+            'property_static_mismatch.php',
+        );
+    }
+
+    public function testInstanceCannotBecomeStatic(): void
+    {
+        $this->exec(
+            'Cannot redeclare non static `A::$x` as static `B::$x`',
+            'property_nonstatic_mismatch.php',
+        );
+    }
+}

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -5375,6 +5375,14 @@ CODE;
                             "`{$parentClass}::\${$name}`; property shadowing across inheritance is not allowed");
                     }
                     $matchedOverrides[$name] = true;
+                    // A static property and an instance property are different
+                    // kinds of storage; Zend forbids redeclaring one as the
+                    // other in either direction.
+                    if (($childProp->flags & Modifiers::STATIC) !== ($parentProp->flags & Modifiers::STATIC)) {
+                        $this->fatalError($classStmt, ($parentProp->flags & Modifiers::STATIC)
+                            ? "Cannot redeclare static `{$parentClass}::\${$name}` as non static `{$className}::\${$name}`"
+                            : "Cannot redeclare non static `{$parentClass}::\${$name}` as static `{$className}::\${$name}`");
+                    }
                     // PHP inherits get and set independently. A child may
                     // override only one hook, or redeclare the property
                     // without hooks while retaining both parent hooks.


### PR DESCRIPTION
Redeclaring a static property as non-static (or the reverse) compiled: `class A { public static int $x = 1; } class B extends A { public int $x = 2; }` — Zend fatals "Cannot redeclare static A::$x as non static B::$x". checkPropertyOverride compared type, visibility, readonly, and final, but never the STATIC flag.

Both directions now rejected with Zend's message.

Part of the split of #39.
