### PR TITLE
fix: enforce interface declaration and merge rules

### DIFF
--- a/phpunit/code/interface_collision_unimplemented.php
+++ b/phpunit/code/interface_collision_unimplemented.php
@@ -1,0 +1,6 @@
+<?php
+interface I1 { public function f(): int; }
+interface I2 { public function f(): string; }
+abstract class C implements I1, I2 {}
+
+function main() {}

--- a/phpunit/code/interface_collision_valid.php
+++ b/phpunit/code/interface_collision_valid.php
@@ -1,0 +1,17 @@
+<?php
+// Compatible multi-extends (covariant), diamond inheritance, and a class
+// method that satisfies both incompatible declarations are all legal.
+interface I1 { public function f(): int; }
+interface I2 { public function f(): int|string; }
+interface J extends I1, I2 {}
+
+interface Base { public function g(): int; }
+interface B1 extends Base {}
+interface B2 extends Base {}
+interface Diamond extends B1, B2 {}
+
+interface S1 { public function h(): int; }
+interface S2 { public function h(): string; }
+class C implements S1, S2 { public function h(): never { throw new Exception('x'); } }
+
+function main() {}

--- a/phpunit/code/interface_extends_cycle.php
+++ b/phpunit/code/interface_extends_cycle.php
@@ -1,0 +1,8 @@
+<?php
+// A cyclic extends graph can only be expressed ahead-of-time (Zend never
+// gets this far: the first declaration already fails with "Interface "B"
+// not found"). The compiler must fail promptly instead of recursing.
+interface A extends B {}
+interface B extends A {}
+
+function main() {}

--- a/phpunit/code/interface_multi_extends_incompatible.php
+++ b/phpunit/code/interface_multi_extends_incompatible.php
@@ -1,0 +1,6 @@
+<?php
+interface I1 { public function f(): int; }
+interface I2 { public function f(): string; }
+interface J extends I1, I2 {}
+
+function main() {}

--- a/phpunit/code/interface_rule_abstract.php
+++ b/phpunit/code/interface_rule_abstract.php
@@ -1,0 +1,4 @@
+<?php
+interface Runner { abstract public function run(): void; }
+
+function main() {}

--- a/phpunit/code/interface_rule_body.php
+++ b/phpunit/code/interface_rule_body.php
@@ -1,0 +1,4 @@
+<?php
+interface Runner { public function run(): void {} }
+
+function main() {}

--- a/phpunit/code/interface_rule_const_private.php
+++ b/phpunit/code/interface_rule_const_private.php
@@ -1,0 +1,4 @@
+<?php
+interface Runner { private const SPEED = 1; }
+
+function main() {}

--- a/phpunit/code/interface_rule_extends_class.php
+++ b/phpunit/code/interface_rule_extends_class.php
@@ -1,0 +1,5 @@
+<?php
+class Base {}
+interface Runner extends Base {}
+
+function main() {}

--- a/phpunit/code/interface_rule_extends_class_forward.php
+++ b/phpunit/code/interface_rule_extends_class_forward.php
@@ -1,0 +1,7 @@
+<?php
+// The parent's declaration appears after the interface, so only the
+// translation phase can know its kind.
+interface Late extends Impl {}
+class Impl {}
+
+function main() {}

--- a/phpunit/code/interface_rule_extends_dup.php
+++ b/phpunit/code/interface_rule_extends_dup.php
@@ -1,0 +1,5 @@
+<?php
+interface A {}
+interface Runner extends A, A {}
+
+function main() {}

--- a/phpunit/code/interface_rule_final.php
+++ b/phpunit/code/interface_rule_final.php
@@ -1,0 +1,4 @@
+<?php
+interface Runner { final public function run(): void; }
+
+function main() {}

--- a/phpunit/code/interface_rule_private.php
+++ b/phpunit/code/interface_rule_private.php
@@ -1,0 +1,4 @@
+<?php
+interface Runner { private function run(): void; }
+
+function main() {}

--- a/phpunit/code/interface_rule_prop_abstract.php
+++ b/phpunit/code/interface_rule_prop_abstract.php
@@ -1,0 +1,4 @@
+<?php
+interface Runner { abstract public int $speed { get; } }
+
+function main() {}

--- a/phpunit/src/InterfaceDeclarationRulesTest.php
+++ b/phpunit/src/InterfaceDeclarationRulesTest.php
@@ -51,4 +51,12 @@ class InterfaceDeclarationRulesTest extends BaseTest
     {
         $this->exec('Property in interface cannot be explicitly abstract', 'interface_rule_prop_abstract.php');
     }
+
+    public function testCyclicExtendsGraphIsRejectedPromptly(): void
+    {
+        // Zend cannot even declare such a graph (`Interface "B" not found`);
+        // ahead-of-time the cycle exists, so the merged-member table builders
+        // must detect it instead of recursing forever.
+        $this->exec('Interface inheritance cycle detected at `B`', 'interface_extends_cycle.php');
+    }
 }

--- a/phpunit/src/InterfaceDeclarationRulesTest.php
+++ b/phpunit/src/InterfaceDeclarationRulesTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Zend interface member declaration rules: implicitly public abstract
+ * methods without bodies, public constants, no explicit abstract on
+ * hooked properties, and extends restricted to (distinct) interfaces.
+ */
+class InterfaceDeclarationRulesTest extends BaseTest
+{
+    public function testInterfaceMethodCannotContainBody(): void
+    {
+        $this->exec('Interface function `Runner::run()` cannot contain body', 'interface_rule_body.php');
+    }
+
+    public function testInterfaceMethodMustNotBeFinal(): void
+    {
+        $this->exec('Interface method `Runner::run()` must not be final', 'interface_rule_final.php');
+    }
+
+    public function testInterfaceMethodMustBePublic(): void
+    {
+        $this->exec('Access type for interface method `Runner::run()` must be public', 'interface_rule_private.php');
+    }
+
+    public function testInterfaceMethodMustNotBeAbstract(): void
+    {
+        $this->exec('Interface method `Runner::run()` must not be abstract', 'interface_rule_abstract.php');
+    }
+
+    public function testInterfaceConstantMustBePublic(): void
+    {
+        $this->exec('Access type for interface constant `Runner::SPEED` must be public', 'interface_rule_const_private.php');
+    }
+
+    public function testInterfaceCannotExtendClass(): void
+    {
+        $this->exec('`Runner` cannot implement `Base` - it is not an interface', 'interface_rule_extends_class.php');
+    }
+
+    public function testExtendsClassDeclaredLaterIsRejected(): void
+    {
+        $this->exec('`Late` cannot implement `Impl` - it is not an interface', 'interface_rule_extends_class_forward.php');
+    }
+
+    public function testInterfaceCannotExtendSameInterfaceTwice(): void
+    {
+        $this->exec('Interface `Runner` cannot implement previously implemented interface `A`', 'interface_rule_extends_dup.php');
+    }
+
+    public function testInterfacePropertyCannotBeExplicitlyAbstract(): void
+    {
+        $this->exec('Property in interface cannot be explicitly abstract', 'interface_rule_prop_abstract.php');
+    }
+}

--- a/phpunit/src/InterfaceMethodCollisionTest.php
+++ b/phpunit/src/InterfaceMethodCollisionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Zend validates the first-seen declaration of a method as an override of
+ * every later same-name declaration when interfaces merge — both for
+ * `interface J extends I1, I2` and for a class implementing several
+ * interfaces without defining the method itself.
+ */
+class InterfaceMethodCollisionTest extends BaseTest
+{
+    public function testIncompatibleMultiExtendsIsRejected(): void
+    {
+        $this->exec(
+            'Declaration of `I1::f()` must be compatible with `I2::f()`',
+            'interface_multi_extends_incompatible.php'
+        );
+    }
+
+    public function testUnimplementedCollisionOnClassIsRejected(): void
+    {
+        $this->exec(
+            'Declaration of `I1::f()` must be compatible with `I2::f()`',
+            'interface_collision_unimplemented.php'
+        );
+    }
+
+    public function testCompatibleAndSatisfiedCollisionsAreAccepted(): void
+    {
+        $this->compile('interface_collision_valid.php');
+    }
+}

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -2272,8 +2272,23 @@ class Preprocessor extends CompilerBase
         $interfaceName = $this->interfaceDef->getNamespacedName(false);
         $interfaceNameLower = strtolower($interfaceName);
 
+        $extendedInterfaces = [];
         foreach ($v->extends as $parent) {
             $parentName = $this->getNamespacedClassName($this->parseIdentifier($parent));
+            // An interface may only extend interfaces. The parent's kind is
+            // only known once its declaration has been prepared; a parent
+            // declared later is validated by the Translator instead.
+            if ($this->hasClass($parentName) || $this->isInternalClass($parentName)) {
+                $this->fatalError($parent, "`{$interfaceName}` cannot implement `{$parentName}` - it is not an interface");
+            }
+            $parentNameLower = strtolower($parentName);
+            if (isset($extendedInterfaces[$parentNameLower])) {
+                $this->fatalError(
+                    $parent,
+                    "Interface `{$interfaceName}` cannot implement previously implemented interface `{$parentName}`",
+                );
+            }
+            $extendedInterfaces[$parentNameLower] = true;
             $this->interfaceDef->extendsList[] = $parentName;
             if ($this->interfaceDef->extends === '') {
                 $this->interfaceDef->extends = $parentName;
@@ -2295,6 +2310,12 @@ class Preprocessor extends CompilerBase
             if ($stmt instanceof Node\Stmt\ClassConst) {
                 foreach ($stmt->consts as $const) {
                     $constName = $this->parseIdentifier($const->name);
+                    if ($stmt->flags & (Modifiers::PRIVATE | Modifiers::PROTECTED)) {
+                        $this->fatalError(
+                            $stmt,
+                            "Access type for interface constant `{$interfaceName}::{$constName}` must be public",
+                        );
+                    }
                     if ($this->interfaceDef->hasConstant($constName)) {
                         $this->fatalError($stmt, "Duplicate constant `{$constName}`");
                     }
@@ -2317,6 +2338,20 @@ class Preprocessor extends CompilerBase
             if ($stmt instanceof Node\Stmt\ClassMethod) {
                 $methodName = $this->getMethodName($stmt);
                 $this->assertKeywordMethodMayBeDeclared($stmt, $methodName, false);
+                // Interface methods are implicitly public and abstract; Zend
+                // rejects the modifiers below in this exact precedence order.
+                if ($stmt->flags & (Modifiers::PRIVATE | Modifiers::PROTECTED)) {
+                    $this->fatalError($stmt, "Access type for interface method `{$interfaceName}::{$methodName}()` must be public");
+                }
+                if ($stmt->flags & Modifiers::ABSTRACT) {
+                    $this->fatalError($stmt, "Interface method `{$interfaceName}::{$methodName}()` must not be abstract");
+                }
+                if ($stmt->flags & Modifiers::FINAL) {
+                    $this->fatalError($stmt, "Interface method `{$interfaceName}::{$methodName}()` must not be final");
+                }
+                if ($stmt->stmts !== null) {
+                    $this->fatalError($stmt, "Interface function `{$interfaceName}::{$methodName}()` cannot contain body");
+                }
                 if ($this->interfaceDef->hasMethod($methodName)) {
                     $this->fatalError($stmt, "Duplicate method `{$methodName}`");
                 }
@@ -2361,6 +2396,12 @@ class Preprocessor extends CompilerBase
     {
         if ($property->hooks === []) {
             $this->fatalError($property, 'Interfaces may only include hooked properties');
+        }
+        if ($property->flags & Modifiers::ABSTRACT) {
+            $this->fatalError(
+                $property,
+                'Property in interface cannot be explicitly abstract. All interface members are implicitly abstract',
+            );
         }
         if ($property->flags & (Modifiers::PRIVATE | Modifiers::PROTECTED)) {
             $this->fatalError($property, 'Property in interface cannot be protected or private');

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -6067,7 +6067,7 @@ CODE;
 
     /**
      * Memoized effective method tables of interfaces (method name => def and
-     * its original declaring interface), mirroring getEffectiveConstantTable().
+     * its original declaring interface).
      *
      * @var array<string, array<string, array{def: MethodDef, origin: string}>>
      */
@@ -6110,6 +6110,15 @@ CODE;
             return;
         }
         $interfaceDef = $this->getInterface($interfaceName);
+
+        // An interface can only extend other interfaces; naming a class here
+        // is a Zend fatal, not a lookup failure.
+        foreach ($interfaceDef->extendsList ?: ($interfaceDef->extends ? [$interfaceDef->extends] : []) as $parentName) {
+            if (!$this->hasInterface($parentName) && !$this->isInternalInterface($parentName) && $this->hasClass($parentName)) {
+                $this->fatalError($interfaceStmt,
+                    "`{$interfaceName}` cannot implement `{$parentName}` - it is not an interface");
+            }
+        }
 
         $table = [];
         foreach ($interfaceDef->methods as $methodName => $methodDef) {

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -6073,27 +6073,42 @@ CODE;
      */
     private array $effectiveInterfaceMethodTables = [];
 
+    /** @var array<string, true> Interface method tables being constructed. */
+    private array $effectiveInterfaceMethodTableVisiting = [];
+
     /** @return array<string, array{def: MethodDef, origin: string}> */
-    private function getEffectiveInterfaceMethodTable(InterfaceDef $def): array
+    private function getEffectiveInterfaceMethodTable(InterfaceDef $def, NodeAbstract $errorNode): array
     {
         $ownName = $def->getNamespacedName(false);
         $key = strtolower($ownName);
         if (isset($this->effectiveInterfaceMethodTables[$key])) {
             return $this->effectiveInterfaceMethodTables[$key];
         }
-        $table = [];
-        foreach ($def->methods as $name => $methodDef) {
-            $table[$name] = ['def' => $methodDef, 'origin' => $ownName];
+        if (isset($this->effectiveInterfaceMethodTableVisiting[$key])) {
+            // A cyclic extends graph would recurse forever; fail promptly with
+            // the same diagnostic getEffectiveConstantTable() uses, so the
+            // helper stays safe regardless of which validation runs first.
+            $this->fatalError($errorNode, "Interface inheritance cycle detected at `{$ownName}`");
         }
-        foreach ($def->extendsList ?: ($def->extends ? [$def->extends] : []) as $parentName) {
-            if (!$this->hasInterface($parentName)) {
-                continue;
+
+        $this->effectiveInterfaceMethodTableVisiting[$key] = true;
+        try {
+            $table = [];
+            foreach ($def->methods as $name => $methodDef) {
+                $table[$name] = ['def' => $methodDef, 'origin' => $ownName];
             }
-            foreach ($this->getEffectiveInterfaceMethodTable($this->getInterface($parentName)) as $name => $entry) {
-                $table[$name] ??= $entry;
+            foreach ($def->extendsList ?: ($def->extends ? [$def->extends] : []) as $parentName) {
+                if (!$this->hasInterface($parentName)) {
+                    continue;
+                }
+                foreach ($this->getEffectiveInterfaceMethodTable($this->getInterface($parentName), $errorNode) as $name => $entry) {
+                    $table[$name] ??= $entry;
+                }
             }
+            return $this->effectiveInterfaceMethodTables[$key] = $table;
+        } finally {
+            unset($this->effectiveInterfaceMethodTableVisiting[$key]);
         }
-        return $this->effectiveInterfaceMethodTables[$key] = $table;
     }
 
     /**
@@ -6128,7 +6143,7 @@ CODE;
             if (!$this->hasInterface($parentName)) {
                 continue;
             }
-            foreach ($this->getEffectiveInterfaceMethodTable($this->getInterface($parentName)) as $methodName => $entry) {
+            foreach ($this->getEffectiveInterfaceMethodTable($this->getInterface($parentName), $interfaceStmt) as $methodName => $entry) {
                 if (!isset($table[$methodName])) {
                     $table[$methodName] = $entry;
                     continue;
@@ -6177,7 +6192,7 @@ CODE;
             if (!$this->hasInterface($interfaceName)) {
                 continue;
             }
-            foreach ($this->getEffectiveInterfaceMethodTable($this->getInterface($interfaceName)) as $methodName => $entry) {
+            foreach ($this->getEffectiveInterfaceMethodTable($this->getInterface($interfaceName), $classStmt) as $methodName => $entry) {
                 if (!isset($table[$methodName])) {
                     $table[$methodName] = $entry;
                     continue;

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -2895,6 +2895,7 @@ CODE;
             } elseif ($v instanceof Node\Stmt\Interface_) {
                 $this->validateInterfaceOverrideAttributes($v);
                 $this->validateInterfaceConstants($v);
+                $this->validateInterfaceMethodCompatibility($v);
             } elseif (!$v instanceof Node\Stmt\Nop) {
                 $this->unsupportedSyntax($v);
             }
@@ -3070,6 +3071,7 @@ CODE;
             } elseif ($v2 instanceof Node\Stmt\Interface_) {
                 $this->validateInterfaceOverrideAttributes($v2);
                 $this->validateInterfaceConstants($v2);
+                $this->validateInterfaceMethodCompatibility($v2);
             } elseif (!$v2 instanceof Node\Stmt\Nop) {
                 $this->unsupportedSyntax($v2);
             }
@@ -4153,6 +4155,7 @@ CODE;
             $this->validateOverrideAttributes($class);
             $this->checkInterfaceImplementations($class);
             $this->checkInheritedConstantContracts($class);
+            $this->checkInterfaceMethodCollisions($class);
             $this->checkInheritedAbstractMethodsAreImplemented($class);
         }
         $code = $this->genNativeMethod($methodCodes);
@@ -4712,9 +4715,10 @@ CODE;
         string $methodName,
         MethodDef $childMethodDef,
         MethodDef $parentMethodDef,
-        string $parentClass
+        string $parentClass,
+        ?string $childClass = null
     ): void {
-        $className = $this->getFullClassName();
+        $className = $childClass ?? $this->getFullClassName();
 
         // PHP allows widening visibility in overrides (e.g. protected -> public),
         // but forbids narrowing it.
@@ -6058,6 +6062,130 @@ CODE;
             $this->fatalError($node,
                 "Declaration of `{$typeName}::{$constName}` must be compatible " .
                 "with `{$incoming['origin']}::{$constName}`");
+        }
+    }
+
+    /**
+     * Memoized effective method tables of interfaces (method name => def and
+     * its original declaring interface), mirroring getEffectiveConstantTable().
+     *
+     * @var array<string, array<string, array{def: MethodDef, origin: string}>>
+     */
+    private array $effectiveInterfaceMethodTables = [];
+
+    /** @return array<string, array{def: MethodDef, origin: string}> */
+    private function getEffectiveInterfaceMethodTable(InterfaceDef $def): array
+    {
+        $ownName = $def->getNamespacedName(false);
+        $key = strtolower($ownName);
+        if (isset($this->effectiveInterfaceMethodTables[$key])) {
+            return $this->effectiveInterfaceMethodTables[$key];
+        }
+        $table = [];
+        foreach ($def->methods as $name => $methodDef) {
+            $table[$name] = ['def' => $methodDef, 'origin' => $ownName];
+        }
+        foreach ($def->extendsList ?: ($def->extends ? [$def->extends] : []) as $parentName) {
+            if (!$this->hasInterface($parentName)) {
+                continue;
+            }
+            foreach ($this->getEffectiveInterfaceMethodTable($this->getInterface($parentName)) as $name => $entry) {
+                $table[$name] ??= $entry;
+            }
+        }
+        return $this->effectiveInterfaceMethodTables[$key] = $table;
+    }
+
+    /**
+     * Zend's interface merge validates the FIRST-seen declaration of a method
+     * as an override of every LATER same-name declaration ("Declaration of
+     * I1::f() must be compatible with I2::f()"): the interface's own method,
+     * or the one inherited from the earliest-listed parent, is the child.
+     */
+    private function validateInterfaceMethodCompatibility(Node\Stmt\Interface_ $interfaceStmt): void
+    {
+        $name = $this->parseIdentifier($interfaceStmt->name);
+        $interfaceName = $this->namespace === '' ? $name : $this->namespace . '\\' . $name;
+        if (!$this->hasInterface($interfaceName)) {
+            return;
+        }
+        $interfaceDef = $this->getInterface($interfaceName);
+
+        $table = [];
+        foreach ($interfaceDef->methods as $methodName => $methodDef) {
+            $table[$methodName] = ['def' => $methodDef, 'origin' => $interfaceName];
+        }
+        foreach ($interfaceDef->extendsList ?: ($interfaceDef->extends ? [$interfaceDef->extends] : []) as $parentName) {
+            if (!$this->hasInterface($parentName)) {
+                continue;
+            }
+            foreach ($this->getEffectiveInterfaceMethodTable($this->getInterface($parentName)) as $methodName => $entry) {
+                if (!isset($table[$methodName])) {
+                    $table[$methodName] = $entry;
+                    continue;
+                }
+                $existing = $table[$methodName];
+                if ($existing['origin'] === $entry['origin']) {
+                    continue; // diamond: same original declaration
+                }
+                $this->validateMethodOverrideSignature(
+                    $interfaceStmt,
+                    $existing['def']->name,
+                    $existing['def'],
+                    $entry['def'],
+                    $entry['origin'],
+                    $existing['origin'],
+                );
+            }
+        }
+    }
+
+    /**
+     * When a class(-like) implements several interfaces declaring the same
+     * method and neither the class nor a userland ancestor defines it, Zend
+     * still validates the interface declarations against each other
+     * (first-seen as the child). A defined method silences this pairwise
+     * check — it is instead validated against every interface individually.
+     */
+    private function checkInterfaceMethodCollisions(Node\Stmt\Class_|Node\Stmt\Enum_ $classStmt): void
+    {
+        $classDef = $this->classDef;
+        $definedInChain = function (string $methodName) use ($classDef): bool {
+            $current = $classDef;
+            while (true) {
+                if ($current->hasMethod($methodName) || $current->hasAbstractMethod($methodName)) {
+                    return true;
+                }
+                if ($current->extends === '' || $current->inheritedFromInternalClass || !$this->hasClass($current->extends)) {
+                    return false;
+                }
+                $current = $this->getClass($current->extends);
+            }
+        };
+
+        $table = [];
+        foreach ($this->getClassImplementedInterfaces($classDef) as $interfaceName) {
+            if (!$this->hasInterface($interfaceName)) {
+                continue;
+            }
+            foreach ($this->getEffectiveInterfaceMethodTable($this->getInterface($interfaceName)) as $methodName => $entry) {
+                if (!isset($table[$methodName])) {
+                    $table[$methodName] = $entry;
+                    continue;
+                }
+                $existing = $table[$methodName];
+                if ($existing['origin'] === $entry['origin'] || $definedInChain($methodName)) {
+                    continue;
+                }
+                $this->validateMethodOverrideSignature(
+                    $classStmt,
+                    $existing['def']->name,
+                    $existing['def'],
+                    $entry['def'],
+                    $entry['origin'],
+                    $existing['origin'],
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Interface declaration and merge rules were unenforced:

- Interface methods with bodies compiled (the body silently became dead code); `final`, `private`/`protected`, and explicit `abstract` modifiers were accepted; non-public interface constants and explicitly-abstract hooked properties too. All are Zend compile fatals (each probed for the exact rule and message).
- `interface I extends SomeClass` either fataled with a misleading missing-symbol message or compiled when the class was declared later; both cases now fail with Zend's "cannot implement … it is not an interface".
- Same-name methods arriving from several extended interfaces — or from several interfaces a class implements without defining the method — were never cross-checked: `interface J extends I1, I2` compiled with mutually incompatible `f()` declarations. The first-seen declaration is now validated as an override of every later one, matching Zend's merge order; diamond inheritance of one original declaration never conflicts, and a method the class chain defines silences the pairwise check (Zend-probed: a `never` return satisfying both incompatible declarations compiles).

Part of the split of #39.
