### PR TITLE
fix(translator): trait member value comparison and adaptation validation

### DIFF
--- a/phpunit/code/trait_adaptations_valid.php
+++ b/phpunit/code/trait_adaptations_valid.php
@@ -1,0 +1,46 @@
+<?php
+trait Inner
+{
+    public function f(): void {}
+}
+
+trait Outer
+{
+    use Inner;
+}
+
+// Aliases resolve methods arriving from NESTED traits, both unqualified and
+// qualified with the directly-used trait.
+class UsesNested
+{
+    use Outer {
+        f as g;
+    }
+}
+
+class UsesNestedQualified
+{
+    use Outer {
+        Outer::f as h;
+    }
+}
+
+trait Winner
+{
+    public function m(): void {}
+}
+
+trait Loser
+{
+    public function other(): void {}
+}
+
+// The overridden trait need not declare the method a precedence rule names.
+class PrecedenceLoserMissing
+{
+    use Winner, Loser {
+        Winner::m insteadof Loser;
+    }
+}
+
+function main() {}

--- a/phpunit/code/trait_alias_missing_method.php
+++ b/phpunit/code/trait_alias_missing_method.php
@@ -1,0 +1,14 @@
+<?php
+trait A
+{
+    public function f(): void {}
+}
+
+class C
+{
+    use A {
+        missing as g;
+    }
+}
+
+function main() {}

--- a/phpunit/code/trait_alias_missing_qualified.php
+++ b/phpunit/code/trait_alias_missing_qualified.php
@@ -1,0 +1,14 @@
+<?php
+trait A
+{
+    public function f(): void {}
+}
+
+class C
+{
+    use A {
+        A::missing as g;
+    }
+}
+
+function main() {}

--- a/phpunit/code/trait_alias_trait_not_used.php
+++ b/phpunit/code/trait_alias_trait_not_used.php
@@ -1,0 +1,19 @@
+<?php
+trait A
+{
+    public function f(): void {}
+}
+
+trait B
+{
+    public function h(): void {}
+}
+
+class C
+{
+    use A {
+        B::h as g;
+    }
+}
+
+function main() {}

--- a/phpunit/code/trait_const_enum_backed_conflict.php
+++ b/phpunit/code/trait_const_enum_backed_conflict.php
@@ -1,0 +1,30 @@
+<?php
+// A shared backing scalar does not make cases of two different backed enums
+// the same value: Zend compares the case objects, not their backing values.
+enum E1: string
+{
+    case Value = 'x';
+}
+
+enum E2: string
+{
+    case Value = 'x';
+}
+
+trait T1
+{
+    const X = E1::Value;
+}
+
+trait T2
+{
+    const X = E2::Value;
+}
+
+class C
+{
+    use T1;
+    use T2;
+}
+
+function main() {}

--- a/phpunit/code/trait_const_enum_case_array_conflict.php
+++ b/phpunit/code/trait_const_enum_case_array_conflict.php
@@ -1,0 +1,30 @@
+<?php
+// Enum-case identity nests recursively: arrays holding same-named cases of
+// two DIFFERENT enums hold distinct case objects, so the definitions conflict.
+enum E1
+{
+    case Value;
+}
+
+enum E2
+{
+    case Value;
+}
+
+trait T1
+{
+    const X = [E1::Value];
+}
+
+trait T2
+{
+    const X = [E2::Value];
+}
+
+class C
+{
+    use T1;
+    use T2;
+}
+
+function main() {}

--- a/phpunit/code/trait_const_enum_case_array_same.php
+++ b/phpunit/code/trait_const_enum_case_array_same.php
@@ -1,0 +1,26 @@
+<?php
+// Enum-case identity nests recursively: two arrays holding the SAME enum case
+// (and equal scalars) are one definition, so composing is legal.
+enum E
+{
+    case A;
+    case B;
+}
+
+trait T1
+{
+    const X = [E::A, 1];
+}
+
+trait T2
+{
+    const X = [E::A, 1];
+}
+
+class C
+{
+    use T1;
+    use T2;
+}
+
+function main() {}

--- a/phpunit/code/trait_const_enum_case_conflict.php
+++ b/phpunit/code/trait_const_enum_case_conflict.php
@@ -1,0 +1,30 @@
+<?php
+// Same-named cases of two DIFFERENT enums are distinct case objects in Zend,
+// so the two definitions of X conflict even though both cases share the name.
+enum E1
+{
+    case Value;
+}
+
+enum E2
+{
+    case Value;
+}
+
+trait T1
+{
+    const X = E1::Value;
+}
+
+trait T2
+{
+    const X = E2::Value;
+}
+
+class C
+{
+    use T1;
+    use T2;
+}
+
+function main() {}

--- a/phpunit/code/trait_const_enum_case_indirect_conflict.php
+++ b/phpunit/code/trait_const_enum_case_indirect_conflict.php
@@ -1,0 +1,42 @@
+<?php
+// Enum-case identity must survive INDIRECT constant references: each trait
+// reads a class constant that holds a case of a different enum, so the two
+// definitions of VALUE are different case objects and Zend rejects the
+// composition even though both cases share the name `Value`.
+enum E1
+{
+    case Value;
+}
+
+enum E2
+{
+    case Value;
+}
+
+class H1
+{
+    public const ITEM = E1::Value;
+}
+
+class H2
+{
+    public const ITEM = E2::Value;
+}
+
+trait T1
+{
+    public const VALUE = H1::ITEM;
+}
+
+trait T2
+{
+    public const VALUE = H2::ITEM;
+}
+
+class C
+{
+    use T1;
+    use T2;
+}
+
+function main() {}

--- a/phpunit/code/trait_const_enum_case_indirect_same.php
+++ b/phpunit/code/trait_const_enum_case_indirect_same.php
@@ -1,0 +1,33 @@
+<?php
+// The SAME enum case reached through an intermediate class constant is one
+// definition: both traits' VALUE evaluate to E1::Value, so composing is
+// legal — the indirection through H1::ITEM must not lose the case identity
+// (a fresh non-interned value per evaluation would falsely conflict here).
+enum E1
+{
+    case Value;
+    case Other;
+}
+
+class H1
+{
+    public const ITEM = E1::Value;
+}
+
+trait T1
+{
+    public const VALUE = H1::ITEM;
+}
+
+trait T2
+{
+    public const VALUE = H1::ITEM;
+}
+
+class C
+{
+    use T1;
+    use T2;
+}
+
+function main() {}

--- a/phpunit/code/trait_const_enum_case_inherited_conflict.php
+++ b/phpunit/code/trait_const_enum_case_inherited_conflict.php
@@ -1,0 +1,50 @@
+<?php
+// Different enum cases reached through INHERITED class constants: neither
+// H1 nor H2 declares ITEM, so both lookups walk up to a parent whose ITEM
+// holds a case of a different enum. The two definitions of VALUE are
+// different case objects and the composition is rejected.
+enum E1
+{
+    case Value;
+}
+
+enum E2
+{
+    case Value;
+}
+
+class B1
+{
+    public const ITEM = E1::Value;
+}
+
+class B2
+{
+    public const ITEM = E2::Value;
+}
+
+class H1 extends B1
+{
+}
+
+class H2 extends B2
+{
+}
+
+trait T1
+{
+    public const VALUE = H1::ITEM;
+}
+
+trait T2
+{
+    public const VALUE = H2::ITEM;
+}
+
+class C
+{
+    use T1;
+    use T2;
+}
+
+function main() {}

--- a/phpunit/code/trait_const_enum_case_inherited_same.php
+++ b/phpunit/code/trait_const_enum_case_inherited_same.php
@@ -1,0 +1,44 @@
+<?php
+// The SAME enum case reached through an INHERITED class constant: H1 does
+// not declare ITEM itself, so the lookup walks up to BaseH. One trait reads
+// the constant through the child, the other through the parent, and one
+// reads the case directly — all three spellings are the same case object,
+// so composing is legal.
+enum E1
+{
+    case Value;
+    case Other;
+}
+
+class BaseH
+{
+    public const ITEM = E1::Value;
+}
+
+class H1 extends BaseH
+{
+}
+
+trait T1
+{
+    public const VALUE = H1::ITEM;
+}
+
+trait T2
+{
+    public const VALUE = BaseH::ITEM;
+}
+
+trait T3
+{
+    public const VALUE = E1::Value;
+}
+
+class C
+{
+    use T1;
+    use T2;
+    use T3;
+}
+
+function main() {}

--- a/phpunit/code/trait_const_enum_case_same.php
+++ b/phpunit/code/trait_const_enum_case_same.php
@@ -1,0 +1,25 @@
+<?php
+// The SAME enum case in both traits is one definition: composing is legal.
+enum E1
+{
+    case Value;
+    case Other;
+}
+
+trait T1
+{
+    const X = E1::Value;
+}
+
+trait T2
+{
+    const X = E1::Value;
+}
+
+class C
+{
+    use T1;
+    use T2;
+}
+
+function main() {}

--- a/phpunit/code/trait_const_enum_diff_case_conflict.php
+++ b/phpunit/code/trait_const_enum_diff_case_conflict.php
@@ -1,0 +1,25 @@
+<?php
+// Different cases of the SAME enum are different case objects: conflict.
+enum E1
+{
+    case Value;
+    case Other;
+}
+
+trait T1
+{
+    const X = E1::Value;
+}
+
+trait T2
+{
+    const X = E1::Other;
+}
+
+class C
+{
+    use T1;
+    use T2;
+}
+
+function main() {}

--- a/phpunit/code/trait_const_enum_marker_string_collision.php
+++ b/phpunit/code/trait_const_enum_marker_string_collision.php
@@ -1,0 +1,26 @@
+<?php
+// A user string can spell ANY byte sequence (PHP strings are binary-safe), so
+// no marker string can stand in for an enum case: Zend rejects this
+// composition because an enum-case object and a string are different values.
+enum E
+{
+    case A;
+}
+
+trait T1
+{
+    const X = E::A;
+}
+
+trait T2
+{
+    const X = "\0enum-case\0e::A";
+}
+
+class C
+{
+    use T1;
+    use T2;
+}
+
+function main() {}

--- a/phpunit/code/trait_const_identity_conflict.php
+++ b/phpunit/code/trait_const_identity_conflict.php
@@ -1,0 +1,18 @@
+<?php
+trait A
+{
+    const X = 1;
+}
+
+trait B
+{
+    const X = 1.0;
+}
+
+class C
+{
+    use A;
+    use B;
+}
+
+function main() {}

--- a/phpunit/code/trait_const_self_reference_namespaced.php
+++ b/phpunit/code/trait_const_self_reference_namespaced.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App;
+
+// One definition spelled two ways: Zend evaluates both initializers and the
+// composed values match. The evaluation resolves `self::PARTS` against a
+// fully qualified trait/class name; the current namespace must not be
+// prepended a second time (`App\App\...`), and the comparison must not fall
+// back to spelling equality (the spellings differ on purpose).
+trait T1
+{
+    const PARTS = [1, 2];
+    const ALL = [...self::PARTS, 9];
+}
+
+trait T2
+{
+    const PARTS = [1, 2];
+    const ALL = [...self::PARTS, 8 + 1];
+}
+
+class C
+{
+    use T1;
+    use T2;
+}
+
+function main(): void
+{
+    var_dump(C::ALL);
+}

--- a/phpunit/code/trait_const_value_conflict.php
+++ b/phpunit/code/trait_const_value_conflict.php
@@ -1,0 +1,18 @@
+<?php
+trait A
+{
+    const int X = 1;
+}
+
+trait B
+{
+    const int X = 3;
+}
+
+class C
+{
+    use A;
+    use B;
+}
+
+function main() {}

--- a/phpunit/code/trait_insteadof_excluded_twice.php
+++ b/phpunit/code/trait_insteadof_excluded_twice.php
@@ -1,0 +1,22 @@
+<?php
+// Both rules pass the winner-existence check, but the same trait method
+// (B::f) may only be excluded once.
+trait A
+{
+    public function f(): void {}
+}
+
+trait B
+{
+    public function f(): void {}
+}
+
+class X
+{
+    use A, B {
+        A::f insteadof B;
+        A::f insteadof B;
+    }
+}
+
+function main() {}

--- a/phpunit/code/trait_insteadof_missing_method.php
+++ b/phpunit/code/trait_insteadof_missing_method.php
@@ -1,0 +1,19 @@
+<?php
+trait A
+{
+    public function f(): void {}
+}
+
+trait B
+{
+    public function g(): void {}
+}
+
+class C
+{
+    use A, B {
+        B::f insteadof A;
+    }
+}
+
+function main() {}

--- a/phpunit/code/trait_insteadof_overwritten_rule.php
+++ b/phpunit/code/trait_insteadof_overwritten_rule.php
@@ -1,0 +1,27 @@
+<?php
+// Two precedence rules name the same loser (B::f): the later C::f rule must
+// not absolve the earlier A::f rule, whose winner method does not exist.
+trait A
+{
+    public function other(): void {}
+}
+
+trait B
+{
+    public function f(): void {}
+}
+
+trait C
+{
+    public function f(): void {}
+}
+
+class X
+{
+    use A, B, C {
+        A::f insteadof B;
+        C::f insteadof B;
+    }
+}
+
+function main() {}

--- a/phpunit/code/trait_insteadof_trait_not_used.php
+++ b/phpunit/code/trait_insteadof_trait_not_used.php
@@ -1,0 +1,24 @@
+<?php
+trait A
+{
+    public function f(): void {}
+}
+
+trait B
+{
+    public function f(): void {}
+}
+
+trait D
+{
+    public function f(): void {}
+}
+
+class C
+{
+    use A, B {
+        A::f insteadof B, D;
+    }
+}
+
+function main() {}

--- a/phpunit/code/trait_insteadof_two_losers.php
+++ b/phpunit/code/trait_insteadof_two_losers.php
@@ -1,0 +1,27 @@
+<?php
+// One winner excluding two different losers is legal: each loser method is
+// excluded exactly once.
+trait A
+{
+    public function f(): void {}
+}
+
+trait B
+{
+    public function f(): void {}
+}
+
+trait C
+{
+    public function f(): void {}
+}
+
+class X
+{
+    use A, B, C {
+        A::f insteadof B;
+        A::f insteadof C;
+    }
+}
+
+function main() {}

--- a/phpunit/code/trait_member_same_value_spelling.php
+++ b/phpunit/code/trait_member_same_value_spelling.php
@@ -1,0 +1,35 @@
+<?php
+trait A
+{
+    const int X = 1 + 1;
+    public array $p = [1, 2];
+    public float $f = 1;
+}
+
+trait B
+{
+    const int X = 2;
+    public array $p = array(1, 2);
+    public float $f = 1.0;
+}
+
+class C
+{
+    use A;
+    use B;
+}
+
+// The class's own members are also compared by value with trait members.
+trait T
+{
+    const int Y = 2 + 3;
+}
+
+class D
+{
+    use T;
+
+    const int Y = 5;
+}
+
+function main() {}

--- a/phpunit/code/trait_prop_value_conflict.php
+++ b/phpunit/code/trait_prop_value_conflict.php
@@ -1,0 +1,18 @@
+<?php
+trait A
+{
+    public array $p = [1, 2];
+}
+
+trait B
+{
+    public array $p = [2, 1];
+}
+
+class C
+{
+    use A;
+    use B;
+}
+
+function main() {}

--- a/phpunit/src/TraitAdaptationValidationTest.php
+++ b/phpunit/src/TraitAdaptationValidationTest.php
@@ -55,4 +55,27 @@ class TraitAdaptationValidationTest extends BaseTest
             'trait_insteadof_trait_not_used.php',
         );
     }
+
+    public function testEveryPrecedenceRuleForOneLoserIsValidated(): void
+    {
+        // The later `C::f insteadof B` names the same loser as the invalid
+        // `A::f insteadof B` and must not overwrite (and thereby absolve) it.
+        $this->exec(
+            'A precedence rule was defined for `A::f` but this method does not exist',
+            'trait_insteadof_overwritten_rule.php',
+        );
+    }
+
+    public function testMethodExcludedTwiceIsRejected(): void
+    {
+        $this->exec(
+            'Failed to evaluate a trait precedence (`f`). Method of trait `B` was defined to be excluded multiple times',
+            'trait_insteadof_excluded_twice.php',
+        );
+    }
+
+    public function testOneWinnerMayExcludeTwoLosers(): void
+    {
+        $this->compile('trait_insteadof_two_losers.php');
+    }
 }

--- a/phpunit/src/TraitAdaptationValidationTest.php
+++ b/phpunit/src/TraitAdaptationValidationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use TypePhp\Exception\TestError;
+
+/**
+ * Zend validates trait adaptations while binding traits: an alias must name a
+ * method that exists in a used trait, and a precedence rule must name used
+ * traits and an existing preferred method (the overridden trait need not
+ * declare it). Methods arriving from nested traits satisfy adaptations on the
+ * directly-used trait.
+ */
+class TraitAdaptationValidationTest extends BaseTest
+{
+    public function testValidAdaptationsCompile(): void
+    {
+        $this->compile('trait_adaptations_valid.php');
+    }
+
+    public function testUnqualifiedAliasForMissingMethod(): void
+    {
+        $this->exec(
+            'An alias (`g`) was defined for method `missing()`, but this method does not exist',
+            'trait_alias_missing_method.php',
+        );
+    }
+
+    public function testQualifiedAliasForMissingMethod(): void
+    {
+        $this->exec(
+            'An alias was defined for `A::missing` but this method does not exist',
+            'trait_alias_missing_qualified.php',
+        );
+    }
+
+    public function testAliasReferencingUnusedTrait(): void
+    {
+        $this->exec(
+            "Required Trait `B` wasn't added to `C`",
+            'trait_alias_trait_not_used.php',
+        );
+    }
+
+    public function testPrecedenceRuleForMissingMethod(): void
+    {
+        $this->exec(
+            'A precedence rule was defined for `B::f` but this method does not exist',
+            'trait_insteadof_missing_method.php',
+        );
+    }
+
+    public function testPrecedenceRuleReferencingUnusedTrait(): void
+    {
+        $this->exec(
+            "Required Trait `D` wasn't added to `C`",
+            'trait_insteadof_trait_not_used.php',
+        );
+    }
+}

--- a/phpunit/src/TraitMemberValueConflictTest.php
+++ b/phpunit/src/TraitMemberValueConflictTest.php
@@ -29,4 +29,24 @@ class TraitMemberValueConflictTest extends BaseTest
     {
         $this->exec('constant `x` already exists', 'trait_const_identity_conflict.php');
     }
+
+    public function testSameEnumCaseInBothTraitsCompiles(): void
+    {
+        $this->compile('trait_const_enum_case_same.php');
+    }
+
+    public function testSameNamedCasesOfDifferentEnumsConflict(): void
+    {
+        $this->exec('constant `x` already exists', 'trait_const_enum_case_conflict.php');
+    }
+
+    public function testDifferentCasesOfSameEnumConflict(): void
+    {
+        $this->exec('constant `x` already exists', 'trait_const_enum_diff_case_conflict.php');
+    }
+
+    public function testSameBackingValueOfDifferentEnumsConflicts(): void
+    {
+        $this->exec('constant `x` already exists', 'trait_const_enum_backed_conflict.php');
+    }
 }

--- a/phpunit/src/TraitMemberValueConflictTest.php
+++ b/phpunit/src/TraitMemberValueConflictTest.php
@@ -54,4 +54,19 @@ class TraitMemberValueConflictTest extends BaseTest
     {
         $this->exec('constant `x` already exists', 'trait_const_enum_backed_conflict.php');
     }
+
+    public function testStringSpellingAnEnumCaseMarkerConflicts(): void
+    {
+        $this->exec('constant `x` already exists', 'trait_const_enum_marker_string_collision.php');
+    }
+
+    public function testSameEnumCaseInsideArraysCompiles(): void
+    {
+        $this->compile('trait_const_enum_case_array_same.php');
+    }
+
+    public function testDifferentEnumCasesInsideArraysConflict(): void
+    {
+        $this->exec('constant `x` already exists', 'trait_const_enum_case_array_conflict.php');
+    }
 }

--- a/phpunit/src/TraitMemberValueConflictTest.php
+++ b/phpunit/src/TraitMemberValueConflictTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use TypePhp\Exception\TestError;
+
+/**
+ * Zend compares trait data members by VALUE when flattening traits into a
+ * class: `1 + 1` and `2`, or `[1, 2]` and `array(1, 2)`, are the same
+ * definition, while genuinely different values (and identical-but-differently
+ * typed ones, e.g. 1 vs 1.0 on an untyped constant) conflict.
+ */
+class TraitMemberValueConflictTest extends BaseTest
+{
+    public function testSameValueDifferentSpellingCompiles(): void
+    {
+        $this->compile('trait_member_same_value_spelling.php');
+    }
+
+    public function testDifferentConstantValuesConflict(): void
+    {
+        $this->exec('constant `x` already exists', 'trait_const_value_conflict.php');
+    }
+
+    public function testDifferentPropertyDefaultsConflict(): void
+    {
+        $this->exec('property `p` already exists', 'trait_prop_value_conflict.php');
+    }
+
+    public function testValueComparisonIsIdentityNotEquality(): void
+    {
+        $this->exec('constant `x` already exists', 'trait_const_identity_conflict.php');
+    }
+}

--- a/phpunit/src/TraitMemberValueConflictTest.php
+++ b/phpunit/src/TraitMemberValueConflictTest.php
@@ -35,6 +35,11 @@ class TraitMemberValueConflictTest extends BaseTest
         $this->compile('trait_const_enum_case_same.php');
     }
 
+    public function testSelfConstantReferenceEvaluatesInNamespace(): void
+    {
+        $this->compile('trait_const_self_reference_namespaced.php');
+    }
+
     public function testSameNamedCasesOfDifferentEnumsConflict(): void
     {
         $this->exec('constant `x` already exists', 'trait_const_enum_case_conflict.php');

--- a/phpunit/src/TraitMemberValueConflictTest.php
+++ b/phpunit/src/TraitMemberValueConflictTest.php
@@ -69,4 +69,24 @@ class TraitMemberValueConflictTest extends BaseTest
     {
         $this->exec('constant `x` already exists', 'trait_const_enum_case_array_conflict.php');
     }
+
+    public function testSameEnumCaseThroughIndirectConstantCompiles(): void
+    {
+        $this->compile('trait_const_enum_case_indirect_same.php');
+    }
+
+    public function testDifferentEnumCasesThroughIndirectConstantsConflict(): void
+    {
+        $this->exec('constant `value` already exists', 'trait_const_enum_case_indirect_conflict.php');
+    }
+
+    public function testSameEnumCaseThroughInheritedConstantCompiles(): void
+    {
+        $this->compile('trait_const_enum_case_inherited_same.php');
+    }
+
+    public function testDifferentEnumCasesThroughInheritedConstantsConflict(): void
+    {
+        $this->exec('constant `value` already exists', 'trait_const_enum_case_inherited_conflict.php');
+    }
 }

--- a/src/Entity/ClassDef.php
+++ b/src/Entity/ClassDef.php
@@ -80,14 +80,18 @@ class ClassDef extends ClassLikeDef
     public array $usedTraits = [];
 
     /**
-     * FullMethodName -> alias list
-     * @var array<string, array<int, array{newName: string, newModifier: int}>>
+     * FullMethodName -> alias list. `group` identifies the source adaptation
+     * (an unqualified alias is registered under every used trait's key),
+     * `method` is the aliased method as written, and `trait` the explicit
+     * trait qualifier or null.
+     * @var array<string, array<int, array{newName: string, newModifier: int, group: string, method: string, trait: ?string}>>
      */
     public array $traitAliases = [];
 
     /**
-     * FullMethodName -> true
-     * @var array<string, bool>
+     * FullMethodName of the ignored (overridden) method -> precedence rule
+     * info for existence validation. Consumers test the key with isset().
+     * @var array<string, array{method: string, winnerTrait: string, loserTrait: string}>
      */
     public array $traitIgnored = [];
     public int $flags;

--- a/src/Entity/ClassDef.php
+++ b/src/Entity/ClassDef.php
@@ -89,9 +89,12 @@ class ClassDef extends ClassLikeDef
     public array $traitAliases = [];
 
     /**
-     * FullMethodName of the ignored (overridden) method -> precedence rule
-     * info for existence validation. Consumers test the key with isset().
-     * @var array<string, array{method: string, winnerTrait: string, loserTrait: string}>
+     * FullMethodName of the ignored (overridden) method -> EVERY precedence
+     * rule that named it as the loser, for existence validation (several
+     * rules may target one loser, and each winner must exist). Consumers
+     * test the key with isset(); legacy writers may store `true` instead of
+     * a rule list, so readers guard with is_array().
+     * @var array<string, array<int, array{method: string, winnerTrait: string, loserTrait: string}>|true>
      */
     public array $traitIgnored = [];
     public int $flags;

--- a/src/Entity/EnumCaseIdentity.php
+++ b/src/Entity/EnumCaseIdentity.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of TypePHP.
+ *
+ * @link     https://www.swoole.com/
+ * @contact  service@swoole.com
+ */
+
+namespace TypePhp\Entity;
+
+/**
+ * Compiler-internal identity of one enum case, returned when a constant
+ * expression is evaluated with identity semantics (see the enumCasesAsIdentity
+ * flag of ClassConstantValueTrait): Zend compares the case OBJECTS when
+ * flattening traits, so E1::Value and E2::Value are different values even
+ * when both share a case name or backing scalar.
+ *
+ * ConstExprEvaluator can only produce scalars, arrays and null from user
+ * code — PHP strings are binary-safe, so even a NUL-prefixed marker string
+ * would be spellable by a user constant — which makes an instance of this
+ * class impossible to collide with. Instances are interned per (enum class,
+ * case name) pair, so `===` is a stable identity test for repeated references
+ * to one case, including recursively inside arrays: PHP's `===` on arrays
+ * compares each element with `===` again, where interned objects only match
+ * themselves.
+ */
+final class EnumCaseIdentity
+{
+    /** @var array<string, self> */
+    private static array $instances = [];
+
+    private function __construct(
+        public readonly string $enumClass,
+        public readonly string $caseName,
+    ) {
+    }
+
+    /**
+     * @param string $enumClass fully qualified enum name (class names are
+     *                          case-insensitive; a leading `\` is ignored)
+     * @param string $caseName case name, compared case-sensitively as Zend does
+     */
+    public static function intern(string $enumClass, string $caseName): self
+    {
+        $normalized = strtolower(ltrim($enumClass, '\\'));
+        return self::$instances[$normalized . '::' . $caseName]
+            ??= new self($normalized, $caseName);
+    }
+}

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -2746,7 +2746,12 @@ class Preprocessor extends CompilerBase
 
     protected function parseTraitUseOptions(Node\Stmt\TraitUse $traitUse, array &$aliases, array &$ignored): void
     {
-        foreach ($traitUse->adaptations as $adaptation) {
+        // Adaptation identity used to verify during trait composition that
+        // every alias matched a real trait method (an unqualified alias is
+        // registered under every used trait's key, so its variants share one
+        // group and the group is satisfied when ANY variant matches).
+        $groupBase = $traitUse->getAttribute('startFilePos', $traitUse->getStartLine()) . '@';
+        foreach ($traitUse->adaptations as $adaptationIndex => $adaptation) {
             if ($adaptation instanceof Node\Stmt\TraitUseAdaptation\Alias) {
                 $traits = [];
                 if (!$adaptation->trait) {
@@ -2769,6 +2774,9 @@ class Preprocessor extends CompilerBase
                     $aliases[$this->getFullMethodName($traitName, $methodName)][] = [
                         'newName' => $adaptation->newName ? $adaptation->newName->toString() : $methodName,
                         'newModifier' => $adaptation->newModifier ?: 0,
+                        'group' => $groupBase . $adaptationIndex,
+                        'method' => $methodName,
+                        'trait' => $adaptation->trait ? $traitName : null,
                     ];
                 }
             }
@@ -2777,6 +2785,7 @@ class Preprocessor extends CompilerBase
                     $this->fatalError($traitUse, 'Trait precedence cannot be used without a trait');
                 }
                 $methodName = $adaptation->method->toString();
+                $winnerTrait = $this->getNamespacedClassName($this->parseIdentifier($adaptation->trait));
                 /*
                  * For example:
                  * use TraitA { TraitA::method insteadof TraitB}
@@ -2784,7 +2793,13 @@ class Preprocessor extends CompilerBase
                  */
                 foreach ($adaptation->insteadof as $trait2) {
                     $traitName = $this->getNamespacedClassName($this->parseIdentifier($trait2));
-                    $ignored[$this->getFullMethodName($traitName, $methodName)] = true;
+                    // The value records the rule for existence validation
+                    // during composition; consumers only use isset() on the key.
+                    $ignored[$this->getFullMethodName($traitName, $methodName)] = [
+                        'method' => $methodName,
+                        'winnerTrait' => $winnerTrait,
+                        'loserTrait' => $traitName,
+                    ];
                 }
             }
         }

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -2793,9 +2793,11 @@ class Preprocessor extends CompilerBase
                  */
                 foreach ($adaptation->insteadof as $trait2) {
                     $traitName = $this->getNamespacedClassName($this->parseIdentifier($trait2));
-                    // The value records the rule for existence validation
-                    // during composition; consumers only use isset() on the key.
-                    $ignored[$this->getFullMethodName($traitName, $methodName)] = [
+                    // The value records EVERY rule targeting this loser method
+                    // for existence validation during composition (several
+                    // precedence rules may name the same loser, and each
+                    // winner must exist); consumers only isset() the key.
+                    $ignored[$this->getFullMethodName($traitName, $methodName)][] = [
                         'method' => $methodName,
                         'winnerTrait' => $winnerTrait,
                         'loserTrait' => $traitName,
@@ -2824,6 +2826,12 @@ class Preprocessor extends CompilerBase
                 $this->classDef->traitAliases[$fullMethodName][] = $alias;
             }
         }
-        $this->classDef->traitIgnored = array_merge($this->classDef->traitIgnored, $ignored);
+        foreach ($ignored as $fullMethodName => $rules) {
+            // Append per key: array_merge() would drop the rules an earlier
+            // `use` clause registered for the same ignored method.
+            foreach ($rules as $rule) {
+                $this->classDef->traitIgnored[$fullMethodName][] = $rule;
+            }
+        }
     }
 }

--- a/src/Resolver/ClassConstantValueTrait.php
+++ b/src/Resolver/ClassConstantValueTrait.php
@@ -164,10 +164,16 @@ trait ClassConstantValueTrait
                 } elseif (strcasecmp($className, 'parent') === 0) {
                     $className = $this->getParentClass($class);
                 }
-                // $class is already fully qualified; mark it absolute so
-                // getClassConstValue() does not prepend the current file's
-                // namespace a second time (`TypePhp\TypePhp\...`).
-                if ($className !== '' && strcasecmp($expr->class->toString(), $className) !== 0) {
+                // A resolved self/parent/static target is already fully
+                // qualified, and a `\App3\C` source spelling is fully
+                // qualified even though Name::toString() strips the leading
+                // backslash. Mark both absolute so getClassConstValue() does
+                // not prepend the current file's namespace a second time
+                // (`TypePhp\TypePhp\...`, `App3\App3\...`).
+                if ($className !== ''
+                    && ($expr->class instanceof Node\Name\FullyQualified
+                        || strcasecmp($expr->class->toString(), $className) !== 0)
+                ) {
                     $className = '\\' . ltrim($className, '\\');
                 }
                 return $this->getClassConstValue($origin ?? $expr, $className, $constName, $class, $enumCasesAsIdentity);

--- a/src/Resolver/ClassConstantValueTrait.php
+++ b/src/Resolver/ClassConstantValueTrait.php
@@ -38,12 +38,14 @@ trait ClassConstantValueTrait
         if ($nativeConst and $expr->hasAttribute('nativeConst')) {
             $constDef = $expr->getAttribute('nativeConst');
             if ($constDef->valueExpr !== null) {
-                return $this->evaluateClassConstValue($expr, $constDef, $class, $name);
+                return $this->evaluateClassConstValue($expr, $constDef, $class, $name, $enumCasesAsIdentity);
             }
             if ($constDef->class !== '') {
                 $refConst = $constDef->class . '::' . $name;
                 if (defined($refConst)) {
-                    return constant($refConst);
+                    return $enumCasesAsIdentity
+                        ? $this->internHostEnumCase(constant($refConst))
+                        : constant($refConst);
                 }
             }
         }
@@ -51,6 +53,9 @@ trait ClassConstantValueTrait
             $constName = $class . '::' . $name;
             if (defined($constName)) {
                 $value = constant($constName);
+                if ($enumCasesAsIdentity) {
+                    return $this->internHostEnumCase($value);
+                }
                 // Internal enum cases (and internal constants holding one)
                 // must keep their identity through constant evaluation.
                 return $value instanceof \UnitEnum
@@ -58,7 +63,7 @@ trait ClassConstantValueTrait
                     : $value;
             }
         }
-        [$inheritedFound, $inherited] = $this->resolveInheritedClassConst($class, $name);
+        [$inheritedFound, $inherited] = $this->resolveInheritedClassConst($class, $name, $enumCasesAsIdentity);
         if ($inheritedFound) {
             return $inherited;
         }
@@ -86,7 +91,7 @@ trait ClassConstantValueTrait
     }
 
     /** @return array{bool, mixed} */
-    protected function resolveInheritedClassConst(string $class, string $name): array
+    protected function resolveInheritedClassConst(string $class, string $name, bool $enumCasesAsIdentity = false): array
     {
         $current = ltrim($class, '\\');
         $visited = [];
@@ -97,10 +102,11 @@ trait ClassConstantValueTrait
                 if ($classDef->hasConstant($name)) {
                     $constDef = $classDef->getConstant($name);
                     if ($constDef->valueExpr !== null) {
-                        return [true, $this->evaluateClassConstValue(null, $constDef, $current, $name)];
+                        return [true, $this->evaluateClassConstValue(null, $constDef, $current, $name, $enumCasesAsIdentity)];
                     }
                     if ($constDef->class !== '' && defined($constDef->class . '::' . $name)) {
-                        return [true, constant($constDef->class . '::' . $name)];
+                        $value = constant($constDef->class . '::' . $name);
+                        return [true, $enumCasesAsIdentity ? $this->internHostEnumCase($value) : $value];
                     }
                 }
                 $current = $classDef->extends;
@@ -110,6 +116,9 @@ trait ClassConstantValueTrait
                 $constName = $current . '::' . $name;
                 if (defined($constName)) {
                     $value = constant($constName);
+                    if ($enumCasesAsIdentity) {
+                        return [true, $this->internHostEnumCase($value)];
+                    }
                     return [true, $value instanceof \UnitEnum
                         ? new EnumCaseRef(get_class($value), $value->name)
                         : $value];
@@ -120,6 +129,21 @@ trait ClassConstantValueTrait
             }
         }
         return [false, null];
+    }
+
+    /**
+     * A value read from the host runtime (constant() on an internal or
+     * already-linked constant) can be a live enum case object. Under identity
+     * semantics it must intern to the same EnumCaseIdentity a compiled enum
+     * case produces, so one case reached through a native, nested or
+     * inherited constant compares identical to the same case reached
+     * directly — and different cases never do.
+     */
+    private function internHostEnumCase(mixed $value): mixed
+    {
+        return $value instanceof \UnitEnum
+            ? EnumCaseIdentity::intern(get_class($value), $value->name)
+            : $value;
     }
 
     protected function evaluateClassConstValue(?NodeAbstract $origin, ConstantDef $constDef, string $class, string $name, bool $enumCasesAsIdentity = false): mixed
@@ -137,7 +161,9 @@ trait ClassConstantValueTrait
                     'false' => false,
                     'null' => null,
                     default => defined($constName)
-                        ? constant($constName)
+                        ? ($enumCasesAsIdentity
+                            ? $this->internHostEnumCase(constant($constName))
+                            : constant($constName))
                         : throw new \RuntimeException("Constant `{$constName}` not found"),
                 };
             }

--- a/src/Resolver/ClassConstantValueTrait.php
+++ b/src/Resolver/ClassConstantValueTrait.php
@@ -16,12 +16,19 @@ use TypePhp\Entity\EnumCaseRef;
 
 trait ClassConstantValueTrait
 {
+    /**
+     * Prefix of the marker string an enum case evaluates to when the caller
+     * asked for identity semantics (see getClassConstValue()). The NUL bytes
+     * make a collision with a real string constant value impossible.
+     */
+    public const ENUM_CASE_IDENTITY_PREFIX = "\0enum-case\0";
+
     public function getDefinedConstants(): array
     {
         return $this->internalConstants;
     }
 
-    public function getClassConstValue(NodeAbstract $expr, string $_class, string $name, string $currentClass = ''): mixed
+    public function getClassConstValue(NodeAbstract $expr, string $_class, string $name, string $currentClass = '', bool $enumCasesAsIdentity = false): mixed
     {
         $namespace = $this->namespace;
         if (!$namespace and $currentClass and !str_contains($_class, '\\')) {
@@ -64,6 +71,16 @@ trait ClassConstantValueTrait
         if ($this->hasClass($class)) {
             $classDef = $this->getClass($class);
             if ($classDef->enum && array_key_exists($name, $classDef->enumCases)) {
+                if ($enumCasesAsIdentity) {
+                    // Each enum case is a distinct object in Zend: two cases
+                    // are the same value only when both the enum class and
+                    // the case name match, never through a shared case name
+                    // or backing scalar. Callers comparing values for
+                    // identity get an uncollidable marker instead.
+                    return self::ENUM_CASE_IDENTITY_PREFIX
+                        . strtolower(ltrim($classDef->getNamespacedName(false), '\\'))
+                        . '::' . $name;
+                }
                 // The case IDENTITY is the constant's value; folding to the
                 // backing scalar (or the case name) would make
                 // `K::CONST === E::Case` false through every dynamic path.
@@ -110,14 +127,14 @@ trait ClassConstantValueTrait
         return [false, null];
     }
 
-    protected function evaluateClassConstValue(?NodeAbstract $origin, ConstantDef $constDef, string $class, string $name): mixed
+    protected function evaluateClassConstValue(?NodeAbstract $origin, ConstantDef $constDef, string $class, string $name, bool $enumCasesAsIdentity = false): mixed
     {
         $valueExpr = $constDef->valueExpr;
         if (!$valueExpr instanceof Node\Expr) {
             $this->fatalError($origin, "Class constant `{$class}::{$name}` has no constant expression");
         }
 
-        $evaluator = new ConstExprEvaluator(function (Node\Expr $expr) use ($origin, $class) {
+        $evaluator = new ConstExprEvaluator(function (Node\Expr $expr) use ($origin, $class, $enumCasesAsIdentity) {
             if ($expr instanceof Node\Expr\ConstFetch) {
                 $constName = $expr->name->toString();
                 return match (strtolower($constName)) {
@@ -147,7 +164,7 @@ trait ClassConstantValueTrait
                 } elseif (strcasecmp($className, 'parent') === 0) {
                     $className = $this->getParentClass($class);
                 }
-                return $this->getClassConstValue($origin ?? $expr, $className, $constName, $class);
+                return $this->getClassConstValue($origin ?? $expr, $className, $constName, $class, $enumCasesAsIdentity);
             }
             throw new \RuntimeException('Unsupported class constant expression');
         });

--- a/src/Resolver/ClassConstantValueTrait.php
+++ b/src/Resolver/ClassConstantValueTrait.php
@@ -12,17 +12,11 @@ use PhpParser\ConstExprEvaluator;
 use PhpParser\Node;
 use PhpParser\NodeAbstract;
 use TypePhp\Entity\ConstantDef;
+use TypePhp\Entity\EnumCaseIdentity;
 use TypePhp\Entity\EnumCaseRef;
 
 trait ClassConstantValueTrait
 {
-    /**
-     * Prefix of the marker string an enum case evaluates to when the caller
-     * asked for identity semantics (see getClassConstValue()). The NUL bytes
-     * make a collision with a real string constant value impossible.
-     */
-    public const ENUM_CASE_IDENTITY_PREFIX = "\0enum-case\0";
-
     public function getDefinedConstants(): array
     {
         return $this->internalConstants;
@@ -76,10 +70,11 @@ trait ClassConstantValueTrait
                     // are the same value only when both the enum class and
                     // the case name match, never through a shared case name
                     // or backing scalar. Callers comparing values for
-                    // identity get an uncollidable marker instead.
-                    return self::ENUM_CASE_IDENTITY_PREFIX
-                        . strtolower(ltrim($classDef->getNamespacedName(false), '\\'))
-                        . '::' . $name;
+                    // identity get an interned compiler-internal object that
+                    // no user constant expression can construct or collide
+                    // with (strings are binary-safe, so a marker string would
+                    // still be spellable).
+                    return EnumCaseIdentity::intern($classDef->getNamespacedName(false), $name);
                 }
                 // The case IDENTITY is the constant's value; folding to the
                 // backing scalar (or the case name) would make

--- a/src/Resolver/ClassConstantValueTrait.php
+++ b/src/Resolver/ClassConstantValueTrait.php
@@ -159,10 +159,16 @@ trait ClassConstantValueTrait
                     }
                     return ltrim($this->getNamespacedClassName($className, $this->getNamespaceOfClass($class)), '\\');
                 }
-                if (strcasecmp($className, 'self') === 0) {
+                if (strcasecmp($className, 'self') === 0 || strcasecmp($className, 'static') === 0) {
                     $className = $class;
                 } elseif (strcasecmp($className, 'parent') === 0) {
                     $className = $this->getParentClass($class);
+                }
+                // $class is already fully qualified; mark it absolute so
+                // getClassConstValue() does not prepend the current file's
+                // namespace a second time (`TypePhp\TypePhp\...`).
+                if ($className !== '' && strcasecmp($expr->class->toString(), $className) !== 0) {
+                    $className = '\\' . ltrim($className, '\\');
                 }
                 return $this->getClassConstValue($origin ?? $expr, $className, $constName, $class, $enumCasesAsIdentity);
             }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -3512,20 +3512,37 @@ CODE;
                 "An alias (`{$newName}`) was defined for method `{$method}()`, but this method does not exist");
         }
 
-        foreach ($classDef->traitIgnored as $rule) {
-            if (!is_array($rule)) {
+        // Every precedence rule that named a loser method is validated: Zend
+        // checks each rule's winner individually, so a later `C::f insteadof
+        // B` never absolves an earlier `A::f insteadof B` whose winner method
+        // does not exist.
+        foreach ($classDef->traitIgnored as $rules) {
+            if (!is_array($rules)) {
                 continue;
             }
-            foreach ([$rule['winnerTrait'], $rule['loserTrait']] as $traitName) {
-                if (!isset($usedTraits[strtolower($traitName)])) {
+            foreach ($rules as $rule) {
+                foreach ([$rule['winnerTrait'], $rule['loserTrait']] as $traitName) {
+                    if (!isset($usedTraits[strtolower($traitName)])) {
+                        $this->fatalError($stmt,
+                            "Required Trait `{$traitName}` wasn't added to `{$className}`");
+                    }
+                }
+                if (!isset($seenTraitMethods[$this->getFullMethodName($rule['winnerTrait'], $rule['method'])])) {
                     $this->fatalError($stmt,
-                        "Required Trait `{$traitName}` wasn't added to `{$className}`");
+                        "A precedence rule was defined for `{$rule['winnerTrait']}::{$rule['method']}` " .
+                        'but this method does not exist');
                 }
             }
-            if (!isset($seenTraitMethods[$this->getFullMethodName($rule['winnerTrait'], $rule['method'])])) {
+        }
+        // A trait method may be excluded only once, even across several `use`
+        // clauses; Zend reports duplicates after every rule passed the
+        // existence checks above.
+        foreach ($classDef->traitIgnored as $rules) {
+            if (is_array($rules) && count($rules) > 1) {
+                $rule = $rules[0];
                 $this->fatalError($stmt,
-                    "A precedence rule was defined for `{$rule['winnerTrait']}::{$rule['method']}` " .
-                    'but this method does not exist');
+                    "Failed to evaluate a trait precedence (`{$rule['method']}`). " .
+                    "Method of trait `{$rule['loserTrait']}` was defined to be excluded multiple times");
             }
         }
     }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -3372,10 +3372,11 @@ CODE;
                                 continue;
                             }
                             if (isset($traitConstants[$constName])) {
-                                [$existingConstStmt, $existingConst] = $traitConstants[$constName];
+                                [$existingConstStmt, $existingConst, $existingConstTrait] = $traitConstants[$constName];
+                                $typeStr = $this->typeNodeToStringOrNull($traitStmt->type);
                                 if ($existingConstStmt->flags !== $traitStmt->flags ||
-                                    $this->typeNodeToStringOrNull($existingConstStmt->type) !== $this->typeNodeToStringOrNull($traitStmt->type) ||
-                                    $this->printer->prettyPrintExpr($existingConst->value) !== $this->printer->prettyPrintExpr($const->value)) {
+                                    $this->typeNodeToStringOrNull($existingConstStmt->type) !== $typeStr ||
+                                    !$this->isSameTraitMemberValue($existingConst->value, $existingConstTrait, $const->value, $traitFullName, $typeStr)) {
                                     $this->fatalError($classStmt, "Trait `{$traitFullName}` constant `{$constName}` already exists");
                                 }
                                 unset($traitStmt->consts[$k2]);
@@ -3384,7 +3385,7 @@ CODE;
                                 }
                                 continue;
                             }
-                            $traitConstants[$constName] = [$traitStmt, $const];
+                            $traitConstants[$constName] = [$traitStmt, $const, $traitFullName];
                         }
                     }
                     if ($traitStmt instanceof Node\Stmt\Property) {
@@ -3401,12 +3402,13 @@ CODE;
                                 continue;
                             }
                             if (isset($traitProperties[$propName])) {
-                                [$existingPropStmt, $existingProp] = $traitProperties[$propName];
-                                $existingDefault = $existingProp->default ? $this->printer->prettyPrintExpr($existingProp->default) : null;
-                                $propDefault = $prop->default ? $this->printer->prettyPrintExpr($prop->default) : null;
+                                [$existingPropStmt, $existingProp, $existingPropTrait] = $traitProperties[$propName];
+                                $typeStr = $this->typeNodeToStringOrNull($traitStmt->type);
                                 if ($existingPropStmt->flags !== $traitStmt->flags ||
-                                    $this->typeNodeToStringOrNull($existingPropStmt->type) !== $this->typeNodeToStringOrNull($traitStmt->type) ||
-                                    $existingDefault !== $propDefault) {
+                                    $this->typeNodeToStringOrNull($existingPropStmt->type) !== $typeStr ||
+                                    ($existingProp->default === null) !== ($prop->default === null) ||
+                                    ($prop->default !== null
+                                        && !$this->isSameTraitMemberValue($existingProp->default, $existingPropTrait, $prop->default, $traitFullName, $typeStr))) {
                                     $this->fatalError($classStmt, "Trait `{$traitFullName}` property `{$propName}` already exists");
                                 }
                                 unset($traitStmt->props[$k2]);
@@ -3430,7 +3432,7 @@ CODE;
                                     "Readonly class `{$compositionOwner}` cannot use trait with a non-readonly property `{$traitFullName}::\${$prop->name->toString()}`",
                                 );
                             }
-                            $traitProperties[$propName] = [$traitStmt, $prop];
+                            $traitProperties[$propName] = [$traitStmt, $prop, $traitFullName];
                         }
                     }
                 }
@@ -3483,233 +3485,44 @@ CODE;
     }
 
     /**
-     * Validate that a concrete method satisfies an abstract requirement
-     * declared by a trait, following Zend's trait-composition rules: the
-     * static modifier must match, an abstract by-reference return must be
-     * kept, the implementation cannot require more parameters, parameter
-     * types are contravariant, and the return type is covariant. Visibility
-     * is deliberately not restricted — Zend allows an implementation of any
-     * visibility to fulfill an abstract trait requirement.
+     * Compare two trait data-member initializers by VALUE, as Zend does when
+     * flattening traits: `1 + 1` and `2`, or `[1, 2]` and `array(1, 2)`, are
+     * the same definition. Comparison is identity (===) after evaluating both
+     * constant expressions; an integer initializer of a float-typed member is
+     * coerced to float first, mirroring Zend's declaration-time coercion.
+     * Falls back to source-text equality when a value cannot be evaluated at
+     * compile time.
      */
-    private function validateTraitAbstractImplementation(
-        Node $errorNode,
-        Node\Stmt\ClassMethod $requirement,
-        string $requirementSource,
-        ?MethodDef $requirementDef,
-        Node\Stmt\ClassMethod $implementation,
-        string $implementationSource,
-        ?MethodDef $implementationDef,
-        ClassDef $usingClassDef,
-    ): void {
-        $requirementName = $requirement->name->toString();
-        $implementationName = $implementation->name->toString();
-        $consumingClass = $usingClassDef->getNamespacedName(false);
-
-        if ($requirement->isStatic() !== $implementation->isStatic()) {
-            $this->fatalError($errorNode, $requirement->isStatic()
-                ? "Cannot make static method `{$requirementSource}::{$requirementName}()` non static in class `{$consumingClass}`"
-                : "Cannot make non static method `{$requirementSource}::{$requirementName}()` static in class `{$consumingClass}`");
-        }
-
-        $incompatible = function () use ($errorNode, $implementationSource, $implementationName, $requirementSource, $requirementName): never {
-            $this->fatalError(
-                $errorNode,
-                "Declaration of `{$implementationSource}::{$implementationName}()` must be compatible " .
-                "with `{$requirementSource}::{$requirementName}()`"
-            );
-        };
-
-        // The requirement's by-reference return must be kept; the
-        // implementation may add one.
-        if ($requirement->byRef && !$implementation->byRef) {
-            $incompatible();
-        }
-
-        if ($this->countRequiredParams($implementation->params) > $this->countRequiredParams($requirement->params)) {
-            $incompatible();
-        }
-        $implParamCount = count($implementation->params);
-        $lastImplParam = $implParamCount > 0 ? $implementation->params[$implParamCount - 1] : null;
-        foreach ($requirement->params as $i => $requiredParam) {
-            // A trailing variadic accepts every remaining requirement position.
-            $implParam = $implementation->params[$i]
-                ?? ($lastImplParam?->variadic ? $lastImplParam : null);
-            if ($implParam === null
-                || $implParam->byRef !== $requiredParam->byRef
-                || ($requiredParam->variadic && !$implParam->variadic)
-            ) {
-                $incompatible();
-            }
-        }
-        foreach ($implementation->params as $i => $implParam) {
-            if ($i >= count($requirement->params) && !$implParam->default && !$implParam->variadic) {
-                $incompatible();
-            }
-        }
-
-        // Type variance is checked on the preprocessed definitions, whose
-        // names were resolved in each declaration's own lexical context.
-        $requirementFunc = $requirementDef?->functionDef;
-        $implementationFunc = $implementationDef?->functionDef;
-        if (!$requirementFunc || !$implementationFunc) {
-            return;
-        }
-
-        $implArgs = $implementationFunc->argInfoList;
-        $lastImplArg = $implArgs === [] ? null : $implArgs[count($implArgs) - 1];
-        foreach ($requirementFunc->argInfoList as $i => $requiredArg) {
-            $implArg = $implArgs[$i] ?? ($lastImplArg?->variadic ? $lastImplArg : null);
-            if ($implArg === null) {
-                continue;
-            }
-            if (!$this->isTraitParameterTypeCompatible(
-                $implArg,
-                $requiredArg,
-                $usingClassDef,
-                $errorNode,
-            )) {
-                $incompatible();
-            }
-        }
-
-        if ($requirementFunc->returnTypeUndeclared) {
-            return;
-        }
-        if ($implementationFunc->returnTypeUndeclared) {
-            $incompatible();
-        }
-        $requirementTypes = $this->getTraitReturnAcceptedTypes(
-            $requirementFunc,
-            $usingClassDef,
-            $errorNode,
-        );
-        $implementationTypes = $this->getTraitReturnAcceptedTypes(
-            $implementationFunc,
-            $usingClassDef,
-            $errorNode,
-        );
-        foreach ($implementationTypes as $implementationType) {
-            if (!$this->isReturnTypeCoveredBy($implementationType, $requirementTypes)) {
-                $incompatible();
-            }
-        }
-    }
-
-    /**
-     * @param array<Node\Param> $params
-     */
-    private function countRequiredParams(array $params): int
-    {
-        $required = 0;
-        foreach (array_values($params) as $i => $param) {
-            if (!$param->default && !$param->variadic) {
-                $required = $i + 1;
-            }
-        }
-        return $required;
-    }
-
-    private function isTraitParameterTypeCompatible(
-        ArgInfo $implementation,
-        ArgInfo $requirement,
-        ClassDef $usingClassDef,
-        Node $errorNode,
+    private function isSameTraitMemberValue(
+        Node\Expr $existingValue,
+        string $existingClass,
+        Node\Expr $incomingValue,
+        string $incomingClass,
+        ?string $declaredTypeStr,
     ): bool {
-        if ($this->isTopParameterType($implementation)) {
-            return true;
+        try {
+            $a = $this->evaluateTraitMemberValue($existingValue, $existingClass);
+            $b = $this->evaluateTraitMemberValue($incomingValue, $incomingClass);
+        } catch (\Throwable) {
+            return $this->printer->prettyPrintExpr($existingValue) === $this->printer->prettyPrintExpr($incomingValue);
         }
-        if ($this->isTopParameterType($requirement)) {
-            return false;
-        }
-
-        $requirementTypes = $this->getTraitParameterAcceptedTypes(
-            $requirement,
-            $usingClassDef,
-            $errorNode,
-        );
-        $implementationTypes = $this->getTraitParameterAcceptedTypes(
-            $implementation,
-            $usingClassDef,
-            $errorNode,
-        );
-        if ($requirementTypes === null || $implementationTypes === null) {
-            return $this->isParameterTypeOverrideCompatible($implementation, $requirement);
-        }
-        return $this->isAcceptedTypeSubset($requirementTypes, $implementationTypes);
-    }
-
-    private function getTraitParameterAcceptedTypes(
-        ArgInfo $argument,
-        ClassDef $usingClassDef,
-        Node $errorNode,
-    ): ?array {
-        if ($argument->typeKeyword !== '') {
-            return $this->getLateBoundTraitAcceptedType($argument->typeKeyword, $usingClassDef, $errorNode);
-        }
-        return $this->resolveLateBoundAcceptedTypes(
-            $this->getParameterAcceptedTypes($argument),
-            $usingClassDef,
-            $errorNode,
-        );
-    }
-
-    private function getTraitReturnAcceptedTypes(
-        FunctionDef $function,
-        ClassDef $usingClassDef,
-        Node $errorNode,
-    ): array {
-        if ($function->returnTypeKeyword !== '') {
-            return $this->getLateBoundTraitAcceptedType($function->returnTypeKeyword, $usingClassDef, $errorNode);
-        }
-        return $this->resolveLateBoundAcceptedTypes(
-            $this->getReturnAcceptedTypes($function, $usingClassDef->getNamespacedName(false)),
-            $usingClassDef,
-            $errorNode,
-        ) ?? [];
-    }
-
-    private function getLateBoundTraitAcceptedType(
-        string $keyword,
-        ClassDef $usingClassDef,
-        Node $errorNode,
-    ): array {
-        if ($keyword === 'static') {
-            return [['kind' => 'isStatic', 'class' => $usingClassDef->getNamespacedName(false)]];
-        }
-        $class = $this->resolveLateBoundClass($usingClassDef, $keyword);
-        if ($class === null) {
-            $this->fatalError($errorNode, 'Cannot use "parent" when current class scope has no parent');
-        }
-        return [['kind' => 'instanceof', 'class' => $class]];
-    }
-
-    private function resolveLateBoundAcceptedTypes(
-        ?array $types,
-        ClassDef $usingClassDef,
-        Node $errorNode,
-    ): ?array {
-        if ($types === null) {
-            return null;
-        }
-        foreach ($types as &$type) {
-            if (($type['kind'] ?? null) === 'allOf') {
-                $type['types'] = $this->resolveLateBoundAcceptedTypes(
-                    $type['types'],
-                    $usingClassDef,
-                    $errorNode,
-                );
-                continue;
+        if ($declaredTypeStr !== null
+            && (strcasecmp($declaredTypeStr, 'float') === 0 || strcasecmp($declaredTypeStr, '?float') === 0)) {
+            if (is_int($a)) {
+                $a = (float) $a;
             }
-            $lateBound = $type['lateBound'] ?? '';
-            if (!is_string($lateBound) || $lateBound === '') {
-                continue;
+            if (is_int($b)) {
+                $b = (float) $b;
             }
-            $resolved = $this->getLateBoundTraitAcceptedType($lateBound, $usingClassDef, $errorNode)[0];
-            $type['kind'] = $resolved['kind'];
-            $type['class'] = $resolved['class'];
-            unset($type['lateBound']);
         }
-        return $types;
+        return $a === $b;
+    }
+
+    private function evaluateTraitMemberValue(Node\Expr $expr, string $class): mixed
+    {
+        $constDef = new ConstantDef('', 0, '', '');
+        $constDef->valueExpr = $expr;
+        return $this->evaluateClassConstValue($expr, $constDef, $class, '');
     }
 
     private function cloneAstNode(Node $node): Node
@@ -6533,20 +6346,57 @@ CODE;
 
     private function isCompatibleTraitConstant(ConstantDef $existing, ConstantDef $incoming): bool
     {
-        return $existing->flags === $incoming->flags
-            && $existing->type === $incoming->type
-            && $existing->class === $incoming->class
-            && $existing->value === $incoming->value;
+        if ($existing->flags !== $incoming->flags
+            || $existing->type !== $incoming->type
+            || $existing->class !== $incoming->class
+        ) {
+            return false;
+        }
+        if ($existing->value === $incoming->value) {
+            return true;
+        }
+        // Different spellings of the same value (e.g. `1 + 1` and `2`) are
+        // compatible in Zend; compare the evaluated values.
+        if ($existing->valueExpr instanceof Node\Expr && $incoming->valueExpr instanceof Node\Expr) {
+            $floatOnly = $existing->declaredType === Type::FLOAT
+                || strcasecmp($existing->typeStr, 'float') === 0
+                || strcasecmp($existing->typeStr, '?float') === 0;
+            return $this->isSameTraitMemberValue(
+                $existing->valueExpr,
+                $this->getFullClassName(),
+                $incoming->valueExpr,
+                $this->getFullClassName(),
+                $floatOnly ? 'float' : null,
+            );
+        }
+        return false;
     }
 
     private function isCompatibleTraitProperty(PropertyDef $existing, PropertyDef $incoming): bool
     {
-        return $existing->flags === $incoming->flags
-            && $existing->type === $incoming->type
-            && $existing->class === $incoming->class
-            && $existing->nullable === $incoming->nullable
-            && $existing->default === $incoming->default
-            && $existing->arrayDef == $incoming->arrayDef;
+        if ($existing->flags !== $incoming->flags
+            || $existing->type !== $incoming->type
+            || $existing->class !== $incoming->class
+            || $existing->nullable !== $incoming->nullable
+        ) {
+            return false;
+        }
+        if ($existing->default === $incoming->default && $existing->arrayDef == $incoming->arrayDef) {
+            return true;
+        }
+        // Different spellings of the same default value (e.g. `1` and `1.0`
+        // on a float property, `[1, 2]` and `array(1, 2)`) are compatible in
+        // Zend; compare the evaluated values.
+        if ($existing->defaultExpr instanceof Node\Expr && $incoming->defaultExpr instanceof Node\Expr) {
+            return $this->isSameTraitMemberValue(
+                $existing->defaultExpr,
+                $this->getFullClassName(),
+                $incoming->defaultExpr,
+                $this->getFullClassName(),
+                $existing->type === Type::FLOAT ? 'float' : null,
+            );
+        }
+        return false;
     }
 
     private function resolveLateBoundClass(ClassDef $usingClassDef, string $keyword): ?string

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -3626,7 +3626,11 @@ CODE;
     {
         $constDef = new ConstantDef('', 0, '', '');
         $constDef->valueExpr = $expr;
-        return $this->evaluateClassConstValue($expr, $constDef, $class, '');
+        // Enum cases must keep their (enum class, case name) identity here:
+        // Zend compares the case OBJECTS when flattening traits, so E1::Value
+        // and E2::Value are different definitions even though both would
+        // otherwise evaluate to the same case-name/backing scalar.
+        return $this->evaluateClassConstValue($expr, $constDef, $class, '', enumCasesAsIdentity: true);
     }
 
     /**
@@ -6686,11 +6690,12 @@ CODE;
         ) {
             return false;
         }
-        if ($existing->value === $incoming->value) {
-            return true;
-        }
-        // Different spellings of the same value (e.g. `1 + 1` and `2`) are
-        // compatible in Zend; compare the evaluated values.
+        // Zend compares the EVALUATED definitions, so different spellings of
+        // one value (`1 + 1` and `2`) are compatible. The evaluated values are
+        // authoritative whenever both expressions are known: the lowered value
+        // string is not an identity (every non-literal initializer shares '',
+        // and E1::Value and E2::Value would both normalize to 'Value' even
+        // though Zend treats the two case objects as distinct).
         if ($existing->valueExpr instanceof Node\Expr && $incoming->valueExpr instanceof Node\Expr) {
             $floatOnly = $existing->declaredType === Type::FLOAT;
             return $this->isSameTraitMemberValue(
@@ -6701,7 +6706,7 @@ CODE;
                 $floatOnly ? 'float' : null,
             );
         }
-        return false;
+        return $existing->value === $incoming->value;
     }
 
     private function isCompatibleTraitProperty(PropertyDef $existing, PropertyDef $incoming): bool

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -3169,6 +3169,8 @@ CODE;
         $traitMethods = [];
         $traitConstants = [];
         $traitProperties = [];
+        $usedTraits = [];
+        $seenTraitMethods = [];
         $classDef = $this->getClass($className->toString());
         $usingClassDef = $classDef;
         $compositionOwner = $classDef->getNamespacedName(false);
@@ -3207,6 +3209,7 @@ CODE;
                 if (!$traitDef->trait) {
                     $this->fatalError($classStmt, "Trait `{$traitFullName}` not found");
                 }
+                $usedTraits[strtolower($traitFullName)] = $traitFullName;
 
                 /** @var Node\Stmt\Trait_ $traitAst */
                 $traitAst = $this->cloneAstNode($traitDef->trait);
@@ -3227,6 +3230,10 @@ CODE;
                             $traitStmt->setAttribute(self::TRAIT_METHOD_ATTRIBUTE, $traitStmt->name->toString());
                         }
                         $fullMethodName = $this->getFullMethodName($traitFullName, $methodName);
+                        // Methods arriving from nested traits are keyed under
+                        // the directly-used trait, matching how adaptation
+                        // keys are registered.
+                        $seenTraitMethods[$fullMethodName] = true;
                         // A trait method's `self`/`static`/`parent` return and parameter
                         // types refer to the class that uses the trait, not the trait
                         // itself. Re-resolve them on the cloned AST so the generated
@@ -3441,6 +3448,86 @@ CODE;
             }
         }
 
+        $this->validateTraitAdaptations($stmt, $classDef, $usedTraits, $seenTraitMethods);
+    }
+
+    /**
+     * After every trait is composed into $classDef, verify that each trait
+     * adaptation named a real trait and a real method, as Zend does when
+     * binding traits:
+     *
+     *  - an alias must reference a used trait, and its method must exist in
+     *    that trait (in any used trait when written without a qualifier);
+     *  - a precedence rule's traits must all be used, and the preferred
+     *    method must exist in the preferred trait (the overridden trait need
+     *    not declare it).
+     *
+     * @param array<string, string> $usedTraits    lowercased name => full name
+     * @param array<string, true>   $seenTraitMethods "trait::method" keys seen
+     *                              during composition (nested trait methods
+     *                              are keyed under the directly-used trait)
+     */
+    private function validateTraitAdaptations(
+        Node\Stmt\ClassLike $stmt,
+        ClassDef $classDef,
+        array $usedTraits,
+        array $seenTraitMethods
+    ): void {
+        if (!$classDef->traitAliases && !$classDef->traitIgnored) {
+            return;
+        }
+        $className = $classDef->getNamespacedName(false);
+
+        // An unqualified alias is registered under every used trait's key (the
+        // Preprocessor cannot know which trait declares the method), so its
+        // variants share one group: the group is satisfied when ANY variant
+        // matched a composed method.
+        $aliasGroups = [];
+        foreach ($classDef->traitAliases as $fullMethodName => $aliasList) {
+            foreach ($aliasList as $alias) {
+                $group = $alias['group'] ?? $fullMethodName;
+                $aliasGroups[$group] ??= ['alias' => $alias, 'matched' => false];
+                if (isset($seenTraitMethods[$fullMethodName])) {
+                    $aliasGroups[$group]['matched'] = true;
+                }
+            }
+        }
+        foreach ($aliasGroups as $groupInfo) {
+            if ($groupInfo['matched']) {
+                continue;
+            }
+            $alias = $groupInfo['alias'];
+            $method = $alias['method'] ?? '';
+            $explicitTrait = $alias['trait'] ?? null;
+            if ($explicitTrait !== null) {
+                if (!isset($usedTraits[strtolower($explicitTrait)])) {
+                    $this->fatalError($stmt,
+                        "Required Trait `{$explicitTrait}` wasn't added to `{$className}`");
+                }
+                $this->fatalError($stmt,
+                    "An alias was defined for `{$explicitTrait}::{$method}` but this method does not exist");
+            }
+            $newName = $alias['newName'] ?? $method;
+            $this->fatalError($stmt,
+                "An alias (`{$newName}`) was defined for method `{$method}()`, but this method does not exist");
+        }
+
+        foreach ($classDef->traitIgnored as $rule) {
+            if (!is_array($rule)) {
+                continue;
+            }
+            foreach ([$rule['winnerTrait'], $rule['loserTrait']] as $traitName) {
+                if (!isset($usedTraits[strtolower($traitName)])) {
+                    $this->fatalError($stmt,
+                        "Required Trait `{$traitName}` wasn't added to `{$className}`");
+                }
+            }
+            if (!isset($seenTraitMethods[$this->getFullMethodName($rule['winnerTrait'], $rule['method'])])) {
+                $this->fatalError($stmt,
+                    "A precedence rule was defined for `{$rule['winnerTrait']}::{$rule['method']}` " .
+                    'but this method does not exist');
+            }
+        }
     }
 
     /**
@@ -3523,6 +3610,236 @@ CODE;
         $constDef = new ConstantDef('', 0, '', '');
         $constDef->valueExpr = $expr;
         return $this->evaluateClassConstValue($expr, $constDef, $class, '');
+    }
+
+    /**
+     * Validate that a concrete method satisfies an abstract requirement
+     * declared by a trait, following Zend's trait-composition rules: the
+     * static modifier must match, an abstract by-reference return must be
+     * kept, the implementation cannot require more parameters, parameter
+     * types are contravariant, and the return type is covariant. Visibility
+     * is deliberately not restricted — Zend allows an implementation of any
+     * visibility to fulfill an abstract trait requirement.
+     */
+    private function validateTraitAbstractImplementation(
+        Node $errorNode,
+        Node\Stmt\ClassMethod $requirement,
+        string $requirementSource,
+        ?MethodDef $requirementDef,
+        Node\Stmt\ClassMethod $implementation,
+        string $implementationSource,
+        ?MethodDef $implementationDef,
+        ClassDef $usingClassDef,
+    ): void {
+        $requirementName = $requirement->name->toString();
+        $implementationName = $implementation->name->toString();
+        $consumingClass = $usingClassDef->getNamespacedName(false);
+
+        if ($requirement->isStatic() !== $implementation->isStatic()) {
+            $this->fatalError($errorNode, $requirement->isStatic()
+                ? "Cannot make static method `{$requirementSource}::{$requirementName}()` non static in class `{$consumingClass}`"
+                : "Cannot make non static method `{$requirementSource}::{$requirementName}()` static in class `{$consumingClass}`");
+        }
+
+        $incompatible = function () use ($errorNode, $implementationSource, $implementationName, $requirementSource, $requirementName): never {
+            $this->fatalError(
+                $errorNode,
+                "Declaration of `{$implementationSource}::{$implementationName}()` must be compatible " .
+                "with `{$requirementSource}::{$requirementName}()`"
+            );
+        };
+
+        // The requirement's by-reference return must be kept; the
+        // implementation may add one.
+        if ($requirement->byRef && !$implementation->byRef) {
+            $incompatible();
+        }
+
+        if ($this->countRequiredParams($implementation->params) > $this->countRequiredParams($requirement->params)) {
+            $incompatible();
+        }
+        $implParamCount = count($implementation->params);
+        $lastImplParam = $implParamCount > 0 ? $implementation->params[$implParamCount - 1] : null;
+        foreach ($requirement->params as $i => $requiredParam) {
+            // A trailing variadic accepts every remaining requirement position.
+            $implParam = $implementation->params[$i]
+                ?? ($lastImplParam?->variadic ? $lastImplParam : null);
+            if ($implParam === null
+                || $implParam->byRef !== $requiredParam->byRef
+                || ($requiredParam->variadic && !$implParam->variadic)
+            ) {
+                $incompatible();
+            }
+        }
+        foreach ($implementation->params as $i => $implParam) {
+            if ($i >= count($requirement->params) && !$implParam->default && !$implParam->variadic) {
+                $incompatible();
+            }
+        }
+
+        // Type variance is checked on the preprocessed definitions, whose
+        // names were resolved in each declaration's own lexical context.
+        $requirementFunc = $requirementDef?->functionDef;
+        $implementationFunc = $implementationDef?->functionDef;
+        if (!$requirementFunc || !$implementationFunc) {
+            return;
+        }
+
+        $implArgs = $implementationFunc->argInfoList;
+        $lastImplArg = $implArgs === [] ? null : $implArgs[count($implArgs) - 1];
+        foreach ($requirementFunc->argInfoList as $i => $requiredArg) {
+            $implArg = $implArgs[$i] ?? ($lastImplArg?->variadic ? $lastImplArg : null);
+            if ($implArg === null) {
+                continue;
+            }
+            if (!$this->isTraitParameterTypeCompatible(
+                $implArg,
+                $requiredArg,
+                $usingClassDef,
+                $errorNode,
+            )) {
+                $incompatible();
+            }
+        }
+
+        if ($requirementFunc->returnTypeUndeclared) {
+            return;
+        }
+        if ($implementationFunc->returnTypeUndeclared) {
+            $incompatible();
+        }
+        $requirementTypes = $this->getTraitReturnAcceptedTypes(
+            $requirementFunc,
+            $usingClassDef,
+            $errorNode,
+        );
+        $implementationTypes = $this->getTraitReturnAcceptedTypes(
+            $implementationFunc,
+            $usingClassDef,
+            $errorNode,
+        );
+        foreach ($implementationTypes as $implementationType) {
+            if (!$this->isReturnTypeCoveredBy($implementationType, $requirementTypes)) {
+                $incompatible();
+            }
+        }
+    }
+
+    /**
+     * @param array<Node\Param> $params
+     */
+    private function countRequiredParams(array $params): int
+    {
+        $required = 0;
+        foreach (array_values($params) as $i => $param) {
+            if (!$param->default && !$param->variadic) {
+                $required = $i + 1;
+            }
+        }
+        return $required;
+    }
+
+    private function isTraitParameterTypeCompatible(
+        ArgInfo $implementation,
+        ArgInfo $requirement,
+        ClassDef $usingClassDef,
+        Node $errorNode,
+    ): bool {
+        if ($this->isTopParameterType($implementation)) {
+            return true;
+        }
+        if ($this->isTopParameterType($requirement)) {
+            return false;
+        }
+
+        $requirementTypes = $this->getTraitParameterAcceptedTypes(
+            $requirement,
+            $usingClassDef,
+            $errorNode,
+        );
+        $implementationTypes = $this->getTraitParameterAcceptedTypes(
+            $implementation,
+            $usingClassDef,
+            $errorNode,
+        );
+        if ($requirementTypes === null || $implementationTypes === null) {
+            return $this->isParameterTypeOverrideCompatible($implementation, $requirement);
+        }
+        return $this->isAcceptedTypeSubset($requirementTypes, $implementationTypes);
+    }
+
+    private function getTraitParameterAcceptedTypes(
+        ArgInfo $argument,
+        ClassDef $usingClassDef,
+        Node $errorNode,
+    ): ?array {
+        if ($argument->typeKeyword !== '') {
+            return $this->getLateBoundTraitAcceptedType($argument->typeKeyword, $usingClassDef, $errorNode);
+        }
+        return $this->resolveLateBoundAcceptedTypes(
+            $this->getParameterAcceptedTypes($argument),
+            $usingClassDef,
+            $errorNode,
+        );
+    }
+
+    private function getTraitReturnAcceptedTypes(
+        FunctionDef $function,
+        ClassDef $usingClassDef,
+        Node $errorNode,
+    ): array {
+        if ($function->returnTypeKeyword !== '') {
+            return $this->getLateBoundTraitAcceptedType($function->returnTypeKeyword, $usingClassDef, $errorNode);
+        }
+        return $this->resolveLateBoundAcceptedTypes(
+            $this->getReturnAcceptedTypes($function, $usingClassDef->getNamespacedName(false)),
+            $usingClassDef,
+            $errorNode,
+        ) ?? [];
+    }
+
+    private function getLateBoundTraitAcceptedType(
+        string $keyword,
+        ClassDef $usingClassDef,
+        Node $errorNode,
+    ): array {
+        if ($keyword === 'static') {
+            return [['kind' => 'isStatic', 'class' => $usingClassDef->getNamespacedName(false)]];
+        }
+        $class = $this->resolveLateBoundClass($usingClassDef, $keyword);
+        if ($class === null) {
+            $this->fatalError($errorNode, 'Cannot use "parent" when current class scope has no parent');
+        }
+        return [['kind' => 'instanceof', 'class' => $class]];
+    }
+
+    private function resolveLateBoundAcceptedTypes(
+        ?array $types,
+        ClassDef $usingClassDef,
+        Node $errorNode,
+    ): ?array {
+        if ($types === null) {
+            return null;
+        }
+        foreach ($types as &$type) {
+            if (($type['kind'] ?? null) === 'allOf') {
+                $type['types'] = $this->resolveLateBoundAcceptedTypes(
+                    $type['types'],
+                    $usingClassDef,
+                    $errorNode,
+                );
+                continue;
+            }
+            $lateBound = $type['lateBound'] ?? '';
+            if (!is_string($lateBound) || $lateBound === '') {
+                continue;
+            }
+            $resolved = $this->getLateBoundTraitAcceptedType($lateBound, $usingClassDef, $errorNode)[0];
+            $type['kind'] = $resolved['kind'];
+            $type['class'] = $resolved['class'];
+            unset($type['lateBound']);
+        }
+        return $types;
     }
 
     private function cloneAstNode(Node $node): Node
@@ -6358,9 +6675,7 @@ CODE;
         // Different spellings of the same value (e.g. `1 + 1` and `2`) are
         // compatible in Zend; compare the evaluated values.
         if ($existing->valueExpr instanceof Node\Expr && $incoming->valueExpr instanceof Node\Expr) {
-            $floatOnly = $existing->declaredType === Type::FLOAT
-                || strcasecmp($existing->typeStr, 'float') === 0
-                || strcasecmp($existing->typeStr, '?float') === 0;
+            $floatOnly = $existing->declaredType === Type::FLOAT;
             return $this->isSameTraitMemberValue(
                 $existing->valueExpr,
                 $this->getFullClassName(),


### PR DESCRIPTION
Two trait-composition gaps:

- Trait constant/property conflicts were compared by pretty-printed source text: two traits declaring `const int X = 1 + 1;` and `const int X = 2;` (or defaults spelled `[1, 2]` vs `array(1, 2)`) were rejected as conflicting, while Zend compares evaluated values. Values are now compared by evaluation — with Zend's declaration-time int→float coercion for float-typed members — falling back to source-text equality only when a value cannot be evaluated at compile time. Different values, visibility, or types still conflict.
- Trait adaptations referencing nonexistent methods were silently ignored: `use A { missing as g; }` and `use A, B { B::f insteadof A; }` (with no `B::f`) both compiled — a typo in an adaptation did nothing. Every alias and precedence rule is now verified against the composed methods, with Zend's diagnostics; an unqualified alias is registered under every used trait, so its variants share one group satisfied by any match, and precedence rules also verify the named traits are actually used.

Verified against Zend 8.4.13; nested-trait aliasing covered.

Part of the split of #39.
