### PR TITLE
fix(preprocessor): reject abstract method bodies and abstract private class methods

### DIFF
--- a/phpunit/code/abstract_rule_body.php
+++ b/phpunit/code/abstract_rule_body.php
@@ -1,0 +1,4 @@
+<?php
+abstract class Job { abstract public function run(): void {} }
+
+function main() {}

--- a/phpunit/code/abstract_rule_private.php
+++ b/phpunit/code/abstract_rule_private.php
@@ -1,0 +1,4 @@
+<?php
+abstract class Job { abstract private function run(): void; }
+
+function main() {}

--- a/phpunit/code/abstract_rule_private_trait_valid.php
+++ b/phpunit/code/abstract_rule_private_trait_valid.php
@@ -1,0 +1,19 @@
+<?php
+trait JobTrait
+{
+    abstract private function run(): void;
+
+    public function go(): void
+    {
+        $this->run();
+    }
+}
+
+class Job
+{
+    use JobTrait;
+
+    private function run(): void {}
+}
+
+function main() {}

--- a/phpunit/src/AbstractMethodDeclarationTest.php
+++ b/phpunit/src/AbstractMethodDeclarationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Zend abstract-method declaration rules: an abstract method may not
+ * carry a body, and abstract private is only legal inside traits.
+ */
+class AbstractMethodDeclarationTest extends BaseTest
+{
+    public function testAbstractMethodCannotContainBody(): void
+    {
+        $this->exec('Abstract function `Job::run()` cannot contain body', 'abstract_rule_body.php');
+    }
+
+    public function testAbstractClassMethodCannotBePrivate(): void
+    {
+        $this->exec('Abstract function `Job::run()` cannot be declared private', 'abstract_rule_private.php');
+    }
+
+    public function testAbstractPrivateTraitMethodIsAllowed(): void
+    {
+        $this->compile('abstract_rule_private_trait_valid.php');
+    }
+}

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -2099,6 +2099,17 @@ class Preprocessor extends CompilerBase
             if ($this->classDef->hasMethod($name) || $this->classDef->hasAbstractMethod($name)) {
                 $this->fatalError($v, "Duplicate method `{$this->method}`");
             }
+            // A private method cannot be overridden, so an abstract private
+            // method could never be implemented. Traits are exempt since PHP
+            // 8.0: the consuming class provides the private implementation.
+            if (!$class instanceof Node\Stmt\Trait_ && ($flags & Modifiers::PRIVATE)) {
+                $this->fatalError($v, "Abstract function `{$this->class}::{$name}()` cannot be declared private");
+            }
+            // An abstract method declares a signature only; Zend rejects a body
+            // instead of silently discarding it.
+            if ($v->stmts !== null) {
+                $this->fatalError($v, "Abstract function `{$this->class}::{$name}()` cannot contain body");
+            }
             if (!$class instanceof Node\Stmt\Trait_ && isset($class->flags) && !($class->flags & Modifiers::ABSTRACT)) {
                 $this->fatalError($v, "Non-abstract class {$this->class} contains abstract method {$v->name}");
             }


### PR DESCRIPTION
Abstract-method declaration rules were unenforced: an abstract method WITH a body compiled (the body silently dropped — Zend: "Abstract function A::f() cannot contain body", also fatal in traits, probed), and `abstract private function` in a class compiled (Zend fatal; legal in traits since PHP 8.0 — the trait exemption is preserved and tested).

Zend's diagnostic precedence (private before body) probed and matched.

Part of the split of #39.
