### PR TITLE
fix(preprocessor): reject variadic promoted properties and callable property/constant types

### DIFF
--- a/phpunit/code/closure_rule_callable_intersection_param.php
+++ b/phpunit/code/closure_rule_callable_intersection_param.php
@@ -1,0 +1,5 @@
+<?php
+function main() {
+    $f = function (Traversable&callable $x): void {};
+    $f(null);
+}

--- a/phpunit/code/closure_rule_callable_intersection_return.php
+++ b/phpunit/code/closure_rule_callable_intersection_return.php
@@ -1,0 +1,5 @@
+<?php
+function main() {
+    $f = function (): Traversable&callable {};
+    $f();
+}

--- a/phpunit/code/const_rule_callable.php
+++ b/phpunit/code/const_rule_callable.php
@@ -1,0 +1,4 @@
+<?php
+class Bag { const callable FN = 1; }
+
+function main() {}

--- a/phpunit/code/const_rule_callable_dnf.php
+++ b/phpunit/code/const_rule_callable_dnf.php
@@ -1,0 +1,4 @@
+<?php
+class Bag { const (Traversable&callable)|int FN = 1; }
+
+function main() {}

--- a/phpunit/code/interface_rule_callable_dnf.php
+++ b/phpunit/code/interface_rule_callable_dnf.php
@@ -1,0 +1,4 @@
+<?php
+interface Baggy { public (Traversable&callable)|stdClass $fn { get; } const (Traversable&callable)|int FN = 1; }
+
+function main() {}

--- a/phpunit/code/param_rule_callable_dnf.php
+++ b/phpunit/code/param_rule_callable_dnf.php
@@ -1,0 +1,4 @@
+<?php
+function consume((Traversable&callable)|stdClass $value): void {}
+
+function main() {}

--- a/phpunit/code/param_rule_callable_intersection.php
+++ b/phpunit/code/param_rule_callable_intersection.php
@@ -1,0 +1,4 @@
+<?php
+function consume(Traversable&callable $value): void {}
+
+function main() {}

--- a/phpunit/code/param_rule_callable_valid.php
+++ b/phpunit/code/param_rule_callable_valid.php
@@ -1,0 +1,8 @@
+<?php
+function apply(callable $fn): void {
+    $fn();
+}
+
+function main() {
+    apply(function (): void {});
+}

--- a/phpunit/code/promotion_rule_variadic.php
+++ b/phpunit/code/promotion_rule_variadic.php
@@ -1,0 +1,4 @@
+<?php
+class Bag { public function __construct(public int ...$items) {} }
+
+function main() {}

--- a/phpunit/code/property_rule_callable.php
+++ b/phpunit/code/property_rule_callable.php
@@ -1,0 +1,4 @@
+<?php
+class Bag { public callable $fn; }
+
+function main() {}

--- a/phpunit/code/property_rule_callable_dnf.php
+++ b/phpunit/code/property_rule_callable_dnf.php
@@ -1,0 +1,4 @@
+<?php
+class Bag { public (Traversable&callable)|stdClass $fn; }
+
+function main() {}

--- a/phpunit/code/property_rule_callable_dnf_promoted.php
+++ b/phpunit/code/property_rule_callable_dnf_promoted.php
@@ -1,0 +1,4 @@
+<?php
+class Bag { public function __construct(public (Traversable&callable)|stdClass $fn) {} }
+
+function main() {}

--- a/phpunit/code/property_rule_callable_dnf_second_member.php
+++ b/phpunit/code/property_rule_callable_dnf_second_member.php
@@ -1,0 +1,4 @@
+<?php
+class Bag { public (Countable&Traversable)|(Iterator&callable) $fn; }
+
+function main() {}

--- a/phpunit/code/property_rule_callable_intersection.php
+++ b/phpunit/code/property_rule_callable_intersection.php
@@ -1,0 +1,4 @@
+<?php
+class Bag { public Traversable&callable $fn; }
+
+function main() {}

--- a/phpunit/code/property_rule_callable_promoted.php
+++ b/phpunit/code/property_rule_callable_promoted.php
@@ -1,0 +1,4 @@
+<?php
+class Bag { public function __construct(public callable $fn) {} }
+
+function main() {}

--- a/phpunit/code/property_rule_callable_union.php
+++ b/phpunit/code/property_rule_callable_union.php
@@ -1,0 +1,4 @@
+<?php
+class Bag { public int|callable $fn; }
+
+function main() {}

--- a/phpunit/code/property_rule_dnf_valid.php
+++ b/phpunit/code/property_rule_dnf_valid.php
@@ -1,0 +1,4 @@
+<?php
+class Bag { public (Countable&Traversable)|stdClass $it; }
+
+function main() {}

--- a/phpunit/code/return_rule_callable_intersection.php
+++ b/phpunit/code/return_rule_callable_intersection.php
@@ -1,0 +1,4 @@
+<?php
+function produce(): Traversable&callable {}
+
+function main() {}

--- a/phpunit/src/PromotionAndPropertyTypeTest.php
+++ b/phpunit/src/PromotionAndPropertyTypeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Constructor promotion and property/constant type restrictions:
+ * no variadic promoted properties, and `callable` is banned from
+ * property and class-constant types (bare, nullable, or union member).
+ */
+class PromotionAndPropertyTypeTest extends BaseTest
+{
+    public function testVariadicPromotedPropertyIsRejected(): void
+    {
+        $this->exec('Cannot declare variadic promoted property', 'promotion_rule_variadic.php');
+    }
+
+    public function testCallablePropertyTypeIsRejected(): void
+    {
+        $this->exec('Property `Bag::$fn` cannot have type `callable`', 'property_rule_callable.php');
+    }
+
+    public function testCallablePromotedPropertyTypeIsRejected(): void
+    {
+        $this->exec('Property `Bag::$fn` cannot have type `callable`', 'property_rule_callable_promoted.php');
+    }
+
+    public function testCallableUnionPropertyTypeIsRejected(): void
+    {
+        $this->exec('Property `Bag::$fn` cannot have type `int|callable`', 'property_rule_callable_union.php');
+    }
+
+    public function testCallableClassConstantTypeIsRejected(): void
+    {
+        $this->exec('Class constant `Bag::FN` cannot have type `callable`', 'const_rule_callable.php');
+    }
+}

--- a/phpunit/src/PromotionAndPropertyTypeTest.php
+++ b/phpunit/src/PromotionAndPropertyTypeTest.php
@@ -31,4 +31,42 @@ class PromotionAndPropertyTypeTest extends BaseTest
     {
         $this->exec('Class constant `Bag::FN` cannot have type `callable`', 'const_rule_callable.php');
     }
+
+    public function testCallableInBareIntersectionIsRejected(): void
+    {
+        // Zend rejects callable while compiling the intersection type itself,
+        // with a dedicated diagnostic; without this check the type reaches
+        // gen_stub, which asserts intersection members are never builtin.
+        $this->exec('Type callable cannot be part of an intersection type', 'property_rule_callable_intersection.php');
+    }
+
+    public function testCallableInDnfPropertyTypeIsRejected(): void
+    {
+        $this->exec('Type callable cannot be part of an intersection type', 'property_rule_callable_dnf.php');
+    }
+
+    public function testCallableInSecondDnfMemberIsRejected(): void
+    {
+        $this->exec('Type callable cannot be part of an intersection type', 'property_rule_callable_dnf_second_member.php');
+    }
+
+    public function testCallableInDnfPromotedPropertyTypeIsRejected(): void
+    {
+        $this->exec('Type callable cannot be part of an intersection type', 'property_rule_callable_dnf_promoted.php');
+    }
+
+    public function testCallableInDnfClassConstantTypeIsRejected(): void
+    {
+        $this->exec('Type callable cannot be part of an intersection type', 'const_rule_callable_dnf.php');
+    }
+
+    public function testCallableInDnfInterfaceMemberTypesIsRejected(): void
+    {
+        $this->exec('Type callable cannot be part of an intersection type', 'interface_rule_callable_dnf.php');
+    }
+
+    public function testCallableFreeDnfPropertyTypeStillCompiles(): void
+    {
+        $this->compile('property_rule_dnf_valid.php');
+    }
 }

--- a/phpunit/src/PromotionAndPropertyTypeTest.php
+++ b/phpunit/src/PromotionAndPropertyTypeTest.php
@@ -2,8 +2,11 @@
 
 /**
  * Constructor promotion and property/constant type restrictions:
- * no variadic promoted properties, and `callable` is banned from
- * property and class-constant types (bare, nullable, or union member).
+ * no variadic promoted properties, `callable` is banned from
+ * property and class-constant types (bare, nullable, or union member),
+ * and `callable` inside an intersection or DNF member is rejected in
+ * every declaration context - parameters, returns, properties, promoted
+ * properties, constants, interface members, and closures.
  */
 class PromotionAndPropertyTypeTest extends BaseTest
 {
@@ -65,8 +68,38 @@ class PromotionAndPropertyTypeTest extends BaseTest
         $this->exec('Type callable cannot be part of an intersection type', 'interface_rule_callable_dnf.php');
     }
 
+    public function testCallableInIntersectionParameterTypeIsRejected(): void
+    {
+        $this->exec('Type callable cannot be part of an intersection type', 'param_rule_callable_intersection.php');
+    }
+
+    public function testCallableInDnfParameterTypeIsRejected(): void
+    {
+        $this->exec('Type callable cannot be part of an intersection type', 'param_rule_callable_dnf.php');
+    }
+
+    public function testCallableInIntersectionReturnTypeIsRejected(): void
+    {
+        $this->exec('Type callable cannot be part of an intersection type', 'return_rule_callable_intersection.php');
+    }
+
+    public function testCallableInIntersectionClosureParameterTypeIsRejected(): void
+    {
+        $this->exec('Type callable cannot be part of an intersection type', 'closure_rule_callable_intersection_param.php');
+    }
+
+    public function testCallableInIntersectionClosureReturnTypeIsRejected(): void
+    {
+        $this->exec('Type callable cannot be part of an intersection type', 'closure_rule_callable_intersection_return.php');
+    }
+
     public function testCallableFreeDnfPropertyTypeStillCompiles(): void
     {
         $this->compile('property_rule_dnf_valid.php');
+    }
+
+    public function testBareCallableParameterTypeStillCompiles(): void
+    {
+        $this->compile('param_rule_callable_valid.php');
     }
 }

--- a/src/Generator/ClosureGenerator.php
+++ b/src/Generator/ClosureGenerator.php
@@ -116,6 +116,20 @@ trait ClosureGenerator
 
     private function doGenClosure(Expr\ArrowFunction|Expr\Closure $expr, array $params, array $uses = []): string
     {
+        // Closure signatures flow through the same declaration validation in
+        // parseTypeDecl() as named functions (e.g. callable inside an
+        // intersection or DNF member). Bare class names are skipped here: the
+        // native-object walk below already resolves each of them through
+        // parseTypeDecl() and owns the trait-context name rewrite, so
+        // resolving them twice would re-qualify an already qualified name.
+        foreach ($params as $param) {
+            if (!$param->type instanceof Node\Name) {
+                $this->resolveTypeDecl($param->type, self::DECL_TYPE_OF_PARAM);
+            }
+        }
+        if (!$expr->returnType instanceof Node\Name) {
+            $this->resolveTypeDecl($expr->returnType, self::DECL_TYPE_OF_RETURN);
+        }
         if ($this->classDef?->nativeObject && !$expr->static) {
             $this->fatalError($expr, 'Native objects cannot be bound as $this to Zend closures');
         }

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -1567,6 +1567,9 @@ class Preprocessor extends CompilerBase
     {
         $this->resetFunction();
         $flags = $this->parseModifiers($v->flags);
+        if ($v->type !== null) {
+            $this->assertTypeDeclIntersectionsHaveNoCallable($v->type, $v);
+        }
         if ($v->type !== null && $this->typeDeclContainsCallable($v->type)) {
             $constName = $v->consts !== [] ? $this->parseIdentifier($v->consts[0]->name) : '';
             $this->fatalError(
@@ -1720,6 +1723,9 @@ class Preprocessor extends CompilerBase
         // `callable` is a runtime-context type (a string or array may or may
         // not be callable depending on scope), so Zend forbids it in property
         // types entirely - bare, nullable, or as a union member.
+        if ($typeNode !== null) {
+            $this->assertTypeDeclIntersectionsHaveNoCallable($typeNode, $errorNode);
+        }
         if ($typeNode !== null && $this->typeDeclContainsCallable($typeNode)) {
             $this->fatalError(
                 $errorNode,
@@ -1798,9 +1804,41 @@ class Preprocessor extends CompilerBase
     }
 
     /**
+     * Zend rejects `callable` as an intersection member while compiling the
+     * type itself ("Type callable cannot be part of an intersection type"),
+     * in every declaration context and before any property/constant-specific
+     * rule fires (probed: `callable|(Traversable&callable)` reports the
+     * intersection conflict, not the property one). This covers bare
+     * intersections and DNF members like `(Traversable&callable)|stdClass`;
+     * without it the type reaches gen_stub, which asserts that intersection
+     * members are never builtin.
+     */
+    private function assertTypeDeclIntersectionsHaveNoCallable(NodeAbstract $typeNode, NodeAbstract $errorNode): void
+    {
+        if ($typeNode instanceof NullableType) {
+            $this->assertTypeDeclIntersectionsHaveNoCallable($typeNode->type, $errorNode);
+            return;
+        }
+        if ($typeNode instanceof UnionType) {
+            foreach ($typeNode->types as $member) {
+                $this->assertTypeDeclIntersectionsHaveNoCallable($member, $errorNode);
+            }
+            return;
+        }
+        if ($typeNode instanceof IntersectionType) {
+            foreach ($typeNode->types as $member) {
+                if (strtolower($this->parseIdentifier($member)) === 'callable') {
+                    $this->fatalError($errorNode, 'Type callable cannot be part of an intersection type');
+                }
+            }
+        }
+    }
+
+    /**
      * Whether a declared type mentions `callable` outside an intersection.
-     * Zend forbids callable in property and class-constant types; members of
-     * an intersection are rejected separately as non-class types.
+     * Zend forbids callable in property and class-constant types; callable
+     * inside an intersection is rejected first, with its own diagnostic, by
+     * assertTypeDeclIntersectionsHaveNoCallable().
      */
     private function typeDeclContainsCallable(NodeAbstract $typeNode): bool
     {
@@ -2489,6 +2527,9 @@ class Preprocessor extends CompilerBase
                             "Access type for interface constant `{$interfaceName}::{$constName}` must be public",
                         );
                     }
+                    if ($stmt->type !== null) {
+                        $this->assertTypeDeclIntersectionsHaveNoCallable($stmt->type, $stmt);
+                    }
                     if ($stmt->type !== null && $this->typeDeclContainsCallable($stmt->type)) {
                         $this->fatalError(
                             $stmt,
@@ -2630,6 +2671,9 @@ class Preprocessor extends CompilerBase
         $nullable = $property->type instanceof NullableType;
         foreach ($property->props as $prop) {
             $name = $this->parseIdentifier($prop->name);
+            if ($property->type !== null) {
+                $this->assertTypeDeclIntersectionsHaveNoCallable($property->type, $property);
+            }
             if ($property->type !== null && $this->typeDeclContainsCallable($property->type)) {
                 $this->fatalError(
                     $property,

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -1567,9 +1567,9 @@ class Preprocessor extends CompilerBase
     {
         $this->resetFunction();
         $flags = $this->parseModifiers($v->flags);
-        if ($v->type !== null) {
-            $this->assertTypeDeclIntersectionsHaveNoCallable($v->type, $v);
-        }
+        [$declaredType, $class] = $v->type
+            ? $this->resolveTypeDecl($v->type, self::DECL_TYPE_OF_CONST)
+            : [null, ''];
         if ($v->type !== null && $this->typeDeclContainsCallable($v->type)) {
             $constName = $v->consts !== [] ? $this->parseIdentifier($v->consts[0]->name) : '';
             $this->fatalError(
@@ -1577,9 +1577,6 @@ class Preprocessor extends CompilerBase
                 "Class constant `{$this->classDef->getNamespacedName(false)}::{$constName}` cannot have type `{$this->typeCheckNodeToString($v->type)}`",
             );
         }
-        [$declaredType, $class] = $v->type
-            ? $this->resolveTypeDecl($v->type, self::DECL_TYPE_OF_CONST)
-            : [null, ''];
 
         foreach ($v->consts as $const) {
             $type = $declaredType;
@@ -1720,19 +1717,19 @@ class Preprocessor extends CompilerBase
             }
         }
         $this->validateAsymmetricPropertyDeclaration($name, $flags, $typeNode, $errorNode);
+        // Resolving the declaration also runs the common compound-type
+        // validation (callable as an intersection/DNF member is rejected
+        // there, ahead of the property-specific rule, matching Zend).
+        [$type, $class] = $this->resolveTypeDecl($typeNode, self::DECL_TYPE_OF_PROPERTY);
         // `callable` is a runtime-context type (a string or array may or may
         // not be callable depending on scope), so Zend forbids it in property
         // types entirely - bare, nullable, or as a union member.
-        if ($typeNode !== null) {
-            $this->assertTypeDeclIntersectionsHaveNoCallable($typeNode, $errorNode);
-        }
         if ($typeNode !== null && $this->typeDeclContainsCallable($typeNode)) {
             $this->fatalError(
                 $errorNode,
                 "Property `{$this->classDef->getNamespacedName(false)}::\${$name}` cannot have type `{$this->typeCheckNodeToString($typeNode)}`",
             );
         }
-        [$type, $class] = $this->resolveTypeDecl($typeNode, self::DECL_TYPE_OF_PROPERTY);
         $this->assertSupportedNativeObjectTypeNode($typeNode, self::DECL_TYPE_OF_PROPERTY, $errorNode);
         $nullableNative = $this->resolveNullableNativeObjectType(
             $typeNode,
@@ -1804,41 +1801,10 @@ class Preprocessor extends CompilerBase
     }
 
     /**
-     * Zend rejects `callable` as an intersection member while compiling the
-     * type itself ("Type callable cannot be part of an intersection type"),
-     * in every declaration context and before any property/constant-specific
-     * rule fires (probed: `callable|(Traversable&callable)` reports the
-     * intersection conflict, not the property one). This covers bare
-     * intersections and DNF members like `(Traversable&callable)|stdClass`;
-     * without it the type reaches gen_stub, which asserts that intersection
-     * members are never builtin.
-     */
-    private function assertTypeDeclIntersectionsHaveNoCallable(NodeAbstract $typeNode, NodeAbstract $errorNode): void
-    {
-        if ($typeNode instanceof NullableType) {
-            $this->assertTypeDeclIntersectionsHaveNoCallable($typeNode->type, $errorNode);
-            return;
-        }
-        if ($typeNode instanceof UnionType) {
-            foreach ($typeNode->types as $member) {
-                $this->assertTypeDeclIntersectionsHaveNoCallable($member, $errorNode);
-            }
-            return;
-        }
-        if ($typeNode instanceof IntersectionType) {
-            foreach ($typeNode->types as $member) {
-                if (strtolower($this->parseIdentifier($member)) === 'callable') {
-                    $this->fatalError($errorNode, 'Type callable cannot be part of an intersection type');
-                }
-            }
-        }
-    }
-
-    /**
      * Whether a declared type mentions `callable` outside an intersection.
      * Zend forbids callable in property and class-constant types; callable
      * inside an intersection is rejected first, with its own diagnostic, by
-     * assertTypeDeclIntersectionsHaveNoCallable().
+     * the common declaration validation in parseTypeDecl().
      */
     private function typeDeclContainsCallable(NodeAbstract $typeNode): bool
     {
@@ -2527,20 +2493,14 @@ class Preprocessor extends CompilerBase
                             "Access type for interface constant `{$interfaceName}::{$constName}` must be public",
                         );
                     }
-                    if ($stmt->type !== null) {
-                        $this->assertTypeDeclIntersectionsHaveNoCallable($stmt->type, $stmt);
-                    }
-                    if ($stmt->type !== null && $this->typeDeclContainsCallable($stmt->type)) {
-                        $this->fatalError(
-                            $stmt,
-                            "Class constant `{$interfaceName}::{$constName}` cannot have type `{$this->typeCheckNodeToString($stmt->type)}`",
-                        );
-                    }
-                    if ($this->interfaceDef->hasConstant($constName)) {
-                        $this->fatalError($stmt, "Duplicate constant `{$constName}`");
-                    }
                     if ($stmt->type) {
                         [$type, $class] = $this->resolveTypeDecl($stmt->type, self::DECL_TYPE_OF_CONST);
+                        if ($this->typeDeclContainsCallable($stmt->type)) {
+                            $this->fatalError(
+                                $stmt,
+                                "Class constant `{$interfaceName}::{$constName}` cannot have type `{$this->typeCheckNodeToString($stmt->type)}`",
+                            );
+                        }
                     } else {
                         $class = '';
                         $type = match ($const->value->getType()) {
@@ -2548,6 +2508,9 @@ class Preprocessor extends CompilerBase
                             'Scalar_String' => Type::STR,
                             default => Type::VAR,
                         };
+                    }
+                    if ($this->interfaceDef->hasConstant($constName)) {
+                        $this->fatalError($stmt, "Duplicate constant `{$constName}`");
                     }
                     $constInfo = $this->parseClassLikeConstant($const, $this->parseModifiers($stmt->flags), $type, $class, $stmt->type ? $type : null);
                     $this->interfaceDef->constants[$constName] = $constInfo;
@@ -2671,9 +2634,6 @@ class Preprocessor extends CompilerBase
         $nullable = $property->type instanceof NullableType;
         foreach ($property->props as $prop) {
             $name = $this->parseIdentifier($prop->name);
-            if ($property->type !== null) {
-                $this->assertTypeDeclIntersectionsHaveNoCallable($property->type, $property);
-            }
             if ($property->type !== null && $this->typeDeclContainsCallable($property->type)) {
                 $this->fatalError(
                     $property,

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -855,6 +855,11 @@ class Preprocessor extends CompilerBase
                 if (!$this->classDef or !$this->methodDef or $this->methodDef->name !== '__construct') {
                     $this->fatalError($param, 'Promoted properties are not supported');
                 }
+                // A variadic parameter collects arguments into an array, so no
+                // single value exists to promote into the property.
+                if ($param->variadic) {
+                    $this->fatalError($param, 'Cannot declare variadic promoted property');
+                }
                 $nullable = $param->type instanceof NullableType;
                 // Promoted property defaults belong to the constructor parameter,
                 // not to the property default table. The property itself must stay
@@ -1562,6 +1567,13 @@ class Preprocessor extends CompilerBase
     {
         $this->resetFunction();
         $flags = $this->parseModifiers($v->flags);
+        if ($v->type !== null && $this->typeDeclContainsCallable($v->type)) {
+            $constName = $v->consts !== [] ? $this->parseIdentifier($v->consts[0]->name) : '';
+            $this->fatalError(
+                $v,
+                "Class constant `{$this->classDef->getNamespacedName(false)}::{$constName}` cannot have type `{$this->typeCheckNodeToString($v->type)}`",
+            );
+        }
         [$declaredType, $class] = $v->type
             ? $this->resolveTypeDecl($v->type, self::DECL_TYPE_OF_CONST)
             : [null, ''];
@@ -1705,6 +1717,15 @@ class Preprocessor extends CompilerBase
             }
         }
         $this->validateAsymmetricPropertyDeclaration($name, $flags, $typeNode, $errorNode);
+        // `callable` is a runtime-context type (a string or array may or may
+        // not be callable depending on scope), so Zend forbids it in property
+        // types entirely - bare, nullable, or as a union member.
+        if ($typeNode !== null && $this->typeDeclContainsCallable($typeNode)) {
+            $this->fatalError(
+                $errorNode,
+                "Property `{$this->classDef->getNamespacedName(false)}::\${$name}` cannot have type `{$this->typeCheckNodeToString($typeNode)}`",
+            );
+        }
         [$type, $class] = $this->resolveTypeDecl($typeNode, self::DECL_TYPE_OF_PROPERTY);
         $this->assertSupportedNativeObjectTypeNode($typeNode, self::DECL_TYPE_OF_PROPERTY, $errorNode);
         $nullableNative = $this->resolveNullableNativeObjectType(
@@ -1774,6 +1795,30 @@ class Preprocessor extends CompilerBase
         }
         $this->classDef->properties[$name] = $propDef;
         return $propDef;
+    }
+
+    /**
+     * Whether a declared type mentions `callable` outside an intersection.
+     * Zend forbids callable in property and class-constant types; members of
+     * an intersection are rejected separately as non-class types.
+     */
+    private function typeDeclContainsCallable(NodeAbstract $typeNode): bool
+    {
+        if ($typeNode instanceof NullableType) {
+            return $this->typeDeclContainsCallable($typeNode->type);
+        }
+        if ($typeNode instanceof UnionType) {
+            foreach ($typeNode->types as $member) {
+                if ($this->typeDeclContainsCallable($member)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if ($typeNode instanceof IntersectionType) {
+            return false;
+        }
+        return strtolower($this->parseIdentifier($typeNode)) === 'callable';
     }
 
     private function validateAsymmetricPropertyDeclaration(
@@ -2444,6 +2489,12 @@ class Preprocessor extends CompilerBase
                             "Access type for interface constant `{$interfaceName}::{$constName}` must be public",
                         );
                     }
+                    if ($stmt->type !== null && $this->typeDeclContainsCallable($stmt->type)) {
+                        $this->fatalError(
+                            $stmt,
+                            "Class constant `{$interfaceName}::{$constName}` cannot have type `{$this->typeCheckNodeToString($stmt->type)}`",
+                        );
+                    }
                     if ($this->interfaceDef->hasConstant($constName)) {
                         $this->fatalError($stmt, "Duplicate constant `{$constName}`");
                     }
@@ -2579,6 +2630,12 @@ class Preprocessor extends CompilerBase
         $nullable = $property->type instanceof NullableType;
         foreach ($property->props as $prop) {
             $name = $this->parseIdentifier($prop->name);
+            if ($property->type !== null && $this->typeDeclContainsCallable($property->type)) {
+                $this->fatalError(
+                    $property,
+                    "Property `{$this->interfaceDef->getNamespacedName(false)}::\${$name}` cannot have type `{$this->typeCheckNodeToString($property->type)}`",
+                );
+            }
             if ($property->getAttribute(FunctionAttributeLowering::OVERRIDE_ATTRIBUTE, false)) {
                 $this->fatalCompileTimeAttribute(
                     $property,

--- a/src/Resolver/NameResolutionTrait.php
+++ b/src/Resolver/NameResolutionTrait.php
@@ -168,6 +168,7 @@ trait NameResolutionTrait
         if ($type === null) {
             return Type::VAR;
         }
+        $this->assertTypeDeclIntersectionsHaveNoCallable($type);
         if ($type instanceof UnionType || $type instanceof NullableType || $type instanceof IntersectionType) {
             // Complex types are uniformly treated as mixed/var at the static stage; the runtime typeCheck provides the fallback.
             return Type::VAR;
@@ -198,6 +199,39 @@ trait NameResolutionTrait
                     $type->name = $class;
                 }
                 return Type::OBJECT;
+            }
+        }
+    }
+
+    /**
+     * Zend rejects `callable` as an intersection member while compiling the
+     * type itself ("Type callable cannot be part of an intersection type"),
+     * in every declaration context - parameters, returns, properties,
+     * promoted properties, class and interface constants, closures - and
+     * before any property/constant-specific rule fires (probed on 8.4.13:
+     * `callable|(Traversable&callable)` reports the intersection conflict,
+     * not the property one). Running the walk here, on the common
+     * declaration path, covers bare intersections and DNF members like
+     * `(Traversable&callable)|stdClass`; without it the type reaches
+     * gen_stub, which asserts that intersection members are never builtin.
+     */
+    private function assertTypeDeclIntersectionsHaveNoCallable(NodeAbstract $typeNode): void
+    {
+        if ($typeNode instanceof NullableType) {
+            $this->assertTypeDeclIntersectionsHaveNoCallable($typeNode->type);
+            return;
+        }
+        if ($typeNode instanceof UnionType) {
+            foreach ($typeNode->types as $member) {
+                $this->assertTypeDeclIntersectionsHaveNoCallable($member);
+            }
+            return;
+        }
+        if ($typeNode instanceof IntersectionType) {
+            foreach ($typeNode->types as $member) {
+                if (strtolower($this->parseIdentifier($member)) === 'callable') {
+                    $this->fatalError($member, 'Type callable cannot be part of an intersection type');
+                }
             }
         }
     }


### PR DESCRIPTION
Two declaration gaps: variadic promoted constructor properties (`__construct(public int ...$x)`) compiled — the promotion was registered before the variadic check (Zend: "Cannot declare variadic promoted property") — and `callable` in property types (declared, promoted, union members) and class/interface constant types was accepted, where Zend rejects it ("Property A::$x cannot have type callable"; constants previously failed only incidentally with a confusing default-value error).

Messages include the full type string for composite types. Each rule probed against Zend 8.4.13.

Part of the split of #39.
