### PR TITLE
fix(preprocessor): validate compound type declarations and class-scope type keywords

### DIFF
--- a/phpunit/code/type_rule_arrow_dup_union.php
+++ b/phpunit/code/type_rule_arrow_dup_union.php
@@ -1,0 +1,4 @@
+<?php
+function main(): void {
+    $fn = fn (int|string|int $value): int|string => $value;
+}

--- a/phpunit/code/type_rule_bool_false.php
+++ b/phpunit/code/type_rule_bool_false.php
@@ -1,0 +1,4 @@
+<?php
+function f(bool|false $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_closure_callable_dnf.php
+++ b/phpunit/code/type_rule_closure_callable_dnf.php
@@ -1,0 +1,4 @@
+<?php
+function main(): void {
+    $closure = function ((Traversable&callable)|stdClass $value): void {};
+}

--- a/phpunit/code/type_rule_closure_dnf_permuted.php
+++ b/phpunit/code/type_rule_closure_dnf_permuted.php
@@ -1,0 +1,8 @@
+<?php
+interface A {}
+
+interface B {}
+
+function main(): void {
+    $closure = function ((A&B)|(B&A) $value): void {};
+}

--- a/phpunit/code/type_rule_closure_dup_union.php
+++ b/phpunit/code/type_rule_closure_dup_union.php
@@ -1,0 +1,4 @@
+<?php
+function main(): void {
+    $closure = function (int|string|int $value): void {};
+}

--- a/phpunit/code/type_rule_closure_intersect_scalar.php
+++ b/phpunit/code/type_rule_closure_intersect_scalar.php
@@ -1,0 +1,4 @@
+<?php
+function main(): void {
+    $closure = function (Countable&int $value): void {};
+}

--- a/phpunit/code/type_rule_closure_self_intersect_global.php
+++ b/phpunit/code/type_rule_closure_self_intersect_global.php
@@ -1,0 +1,4 @@
+<?php
+function main(): void {
+    $closure = function (self&Countable $value): void {};
+}

--- a/phpunit/code/type_rule_closure_self_return_valid.php
+++ b/phpunit/code/type_rule_closure_self_return_valid.php
@@ -1,0 +1,6 @@
+<?php
+function main(): void {
+    $closure = function (self $value): self {
+        throw new Exception('never bound');
+    };
+}

--- a/phpunit/code/type_rule_closure_static_return_valid.php
+++ b/phpunit/code/type_rule_closure_static_return_valid.php
@@ -1,0 +1,6 @@
+<?php
+function main(): void {
+    $closure = function (): static {
+        throw new Exception('never bound');
+    };
+}

--- a/phpunit/code/type_rule_dnf_permuted.php
+++ b/phpunit/code/type_rule_dnf_permuted.php
@@ -1,0 +1,4 @@
+<?php
+interface A {} interface B {} function f((A&B)|(B&A) $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_dnf_subset.php
+++ b/phpunit/code/type_rule_dnf_subset.php
@@ -1,0 +1,4 @@
+<?php
+interface A {} interface B {} function f((A&B)|A $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_dnf_subset_reversed.php
+++ b/phpunit/code/type_rule_dnf_subset_reversed.php
@@ -1,0 +1,4 @@
+<?php
+interface A {} interface B {} function f(A|(A&B) $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_dnf_superset_group.php
+++ b/phpunit/code/type_rule_dnf_superset_group.php
@@ -1,0 +1,4 @@
+<?php
+interface A {} interface B {} interface C2 {} function f((A&B)|(A&B&C2) $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_dup_class_union.php
+++ b/phpunit/code/type_rule_dup_class_union.php
@@ -1,0 +1,5 @@
+<?php
+class Foo {}
+function f(Foo|Foo $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_dup_union.php
+++ b/phpunit/code/type_rule_dup_union.php
@@ -1,0 +1,4 @@
+<?php
+function f(int|string|int $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_implements_dup.php
+++ b/phpunit/code/type_rule_implements_dup.php
@@ -1,0 +1,5 @@
+<?php
+interface Ia {}
+class C implements Ia, Ia {}
+
+function main() {}

--- a/phpunit/code/type_rule_intersect_dup.php
+++ b/phpunit/code/type_rule_intersect_dup.php
@@ -1,0 +1,5 @@
+<?php
+interface Ix {}
+function f(Ix&Ix $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_intersect_scalar.php
+++ b/phpunit/code/type_rule_intersect_scalar.php
@@ -1,0 +1,4 @@
+<?php
+function f(int&string $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_iterable_array.php
+++ b/phpunit/code/type_rule_iterable_array.php
@@ -1,0 +1,4 @@
+<?php
+function f(iterable|array $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_keyword_beside_dnf_valid.php
+++ b/phpunit/code/type_rule_keyword_beside_dnf_valid.php
@@ -1,0 +1,11 @@
+<?php
+interface Ia {} interface Ib {} class B {}
+class C extends B implements Ia, Ib
+{
+    public function m((Ia&Ib)|self $a, (Ia&Ib)|parent $b): (Ia&Ib)|static
+    {
+        return $this;
+    }
+}
+
+function main() {}

--- a/phpunit/code/type_rule_mixed_union.php
+++ b/phpunit/code/type_rule_mixed_union.php
@@ -1,0 +1,4 @@
+<?php
+function f(mixed|int $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_nullable_mixed.php
+++ b/phpunit/code/type_rule_nullable_mixed.php
@@ -1,0 +1,4 @@
+<?php
+function f(?mixed $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_object_class_union.php
+++ b/phpunit/code/type_rule_object_class_union.php
@@ -1,0 +1,4 @@
+<?php
+class Foo {} function f(object|Foo $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_object_class_union_reversed.php
+++ b/phpunit/code/type_rule_object_class_union_reversed.php
@@ -1,0 +1,4 @@
+<?php
+class Foo {} function f(Foo|object $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_object_dnf_union.php
+++ b/phpunit/code/type_rule_object_dnf_union.php
@@ -1,0 +1,4 @@
+<?php
+interface A {} interface B {} function f(object|(A&B) $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_object_interface_union.php
+++ b/phpunit/code/type_rule_object_interface_union.php
@@ -1,0 +1,4 @@
+<?php
+interface Ifc {} function f(Ifc|object $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_parent_dnf_const.php
+++ b/phpunit/code/type_rule_parent_dnf_const.php
@@ -1,0 +1,4 @@
+<?php
+interface Ix {} class Other {} class B {} class C extends B { public const (parent&Ix)|Other X = null; }
+
+function main() {}

--- a/phpunit/code/type_rule_parent_dnf_method.php
+++ b/phpunit/code/type_rule_parent_dnf_method.php
@@ -1,0 +1,4 @@
+<?php
+interface Ix {} class Other {} class B {} class C extends B { public function m((parent&Ix)|Other $x): void {} }
+
+function main() {}

--- a/phpunit/code/type_rule_parent_no_parent_method.php
+++ b/phpunit/code/type_rule_parent_no_parent_method.php
@@ -1,0 +1,4 @@
+<?php
+class C { public function m(parent $x): void {} }
+
+function main() {}

--- a/phpunit/code/type_rule_parent_no_parent_property.php
+++ b/phpunit/code/type_rule_parent_no_parent_property.php
@@ -1,0 +1,4 @@
+<?php
+class C { public parent $p; }
+
+function main() {}

--- a/phpunit/code/type_rule_parent_param_global.php
+++ b/phpunit/code/type_rule_parent_param_global.php
@@ -1,0 +1,4 @@
+<?php
+function f(parent $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_scope_valid.php
+++ b/phpunit/code/type_rule_scope_valid.php
@@ -1,0 +1,47 @@
+<?php
+class ParentClass {}
+
+class ChildClass extends ParentClass
+{
+    public self $again;
+
+    public const self|int MARKER = 1;
+
+    public function m(self $a, ?parent $b): self|static
+    {
+        return $this;
+    }
+}
+
+trait LateBound
+{
+    public function pass(parent $x): parent
+    {
+        return $x;
+    }
+}
+
+interface SelfContract
+{
+    public function m(self $x): self;
+}
+
+enum SelfEnum: int
+{
+    case One = 1;
+
+    public function pick(self $other): self
+    {
+        return $other;
+    }
+}
+
+function closureKeepsRuntimeScope(): int
+{
+    $f = function (self $x): self {
+        return $x;
+    };
+    return 1;
+}
+
+function main() {}

--- a/phpunit/code/type_rule_self_dnf_method.php
+++ b/phpunit/code/type_rule_self_dnf_method.php
@@ -1,0 +1,4 @@
+<?php
+interface Ix {} class Other {} class C { public function m((self&Ix)|Other $x): void {} }
+
+function main() {}

--- a/phpunit/code/type_rule_self_dnf_param_global.php
+++ b/phpunit/code/type_rule_self_dnf_param_global.php
@@ -1,0 +1,4 @@
+<?php
+interface A {} interface B {} function f((A&B)|self $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_self_dnf_promoted.php
+++ b/phpunit/code/type_rule_self_dnf_promoted.php
@@ -1,0 +1,4 @@
+<?php
+interface Ix {} class Other {} class C { public function __construct(public (self&Ix)|Other $p) {} }
+
+function main() {}

--- a/phpunit/code/type_rule_self_dnf_property.php
+++ b/phpunit/code/type_rule_self_dnf_property.php
@@ -1,0 +1,4 @@
+<?php
+interface Ix {} class Other {} class C { public (self&Ix)|Other $p; }
+
+function main() {}

--- a/phpunit/code/type_rule_self_intersect_method.php
+++ b/phpunit/code/type_rule_self_intersect_method.php
@@ -1,0 +1,4 @@
+<?php
+interface Ix {} class C { public function m(self&Ix $x): void {} }
+
+function main() {}

--- a/phpunit/code/type_rule_self_nullable_param_global.php
+++ b/phpunit/code/type_rule_self_nullable_param_global.php
@@ -1,0 +1,4 @@
+<?php
+function f(?self $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_self_param_global.php
+++ b/phpunit/code/type_rule_self_param_global.php
@@ -1,0 +1,4 @@
+<?php
+function f(self $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_self_return_global.php
+++ b/phpunit/code/type_rule_self_return_global.php
@@ -1,0 +1,4 @@
+<?php
+function f(): self {}
+
+function main() {}

--- a/phpunit/code/type_rule_self_union_return_global.php
+++ b/phpunit/code/type_rule_self_union_return_global.php
@@ -1,0 +1,4 @@
+<?php
+function g(): self|stdClass { return new stdClass(); }
+
+function main() {}

--- a/phpunit/code/type_rule_static_dnf_return.php
+++ b/phpunit/code/type_rule_static_dnf_return.php
@@ -1,0 +1,4 @@
+<?php
+interface Ix {} class Other {} class C { public function m(): (static&Ix)|Other { return $this; } }
+
+function main() {}

--- a/phpunit/code/type_rule_static_intersect_return.php
+++ b/phpunit/code/type_rule_static_intersect_return.php
@@ -1,0 +1,4 @@
+<?php
+interface Ix {} class C { public function m(): static&Ix { return $this; } }
+
+function main() {}

--- a/phpunit/code/type_rule_static_return_global.php
+++ b/phpunit/code/type_rule_static_return_global.php
@@ -1,0 +1,4 @@
+<?php
+function f(): static {}
+
+function main() {}

--- a/phpunit/code/type_rule_static_union_return_global.php
+++ b/phpunit/code/type_rule_static_union_return_global.php
@@ -1,0 +1,4 @@
+<?php
+function g(): int|static { return 1; }
+
+function main() {}

--- a/phpunit/code/type_rule_true_false.php
+++ b/phpunit/code/type_rule_true_false.php
@@ -1,0 +1,4 @@
+<?php
+function f(true|false $x): void {}
+
+function main() {}

--- a/phpunit/code/type_rule_valid.php
+++ b/phpunit/code/type_rule_valid.php
@@ -2,5 +2,7 @@
 interface Ia {}
 interface Ib {}
 class TypeOk { public int|string $u; public function m(int|false $a, iterable $c, (Ia&Ib)|string $d): static { return $this; } }
+class Other {}
+function acceptsDistinctClasses(TypeOk|Other $x, (Ia&Ib)|Other $y, (Ia&Ib)|null $z): void {}
 
 function main() {}

--- a/phpunit/code/type_rule_valid.php
+++ b/phpunit/code/type_rule_valid.php
@@ -1,0 +1,6 @@
+<?php
+interface Ia {}
+interface Ib {}
+class TypeOk { public int|string $u; public function m(int|false $a, iterable $c, (Ia&Ib)|string $d): static { return $this; } }
+
+function main() {}

--- a/phpunit/code/type_rule_void_union.php
+++ b/phpunit/code/type_rule_void_union.php
@@ -1,0 +1,4 @@
+<?php
+function f(): void|int {}
+
+function main() {}

--- a/phpunit/src/ClassTest.php
+++ b/phpunit/src/ClassTest.php
@@ -812,17 +812,17 @@ class ClassTest extends \BaseTest
 
     public function testSelfCannotBePartOfIntersectionType()
     {
-        $this->exec("Type 'self' cannot be part of an intersection type", 'intersection_type_self_not_allowed.php');
+        $this->exec('Type `self` cannot be part of an intersection type', 'intersection_type_self_not_allowed.php');
     }
 
     public function testParentCannotBePartOfIntersectionType()
     {
-        $this->exec("Type 'parent' cannot be part of an intersection type", 'intersection_type_parent_not_allowed.php');
+        $this->exec('Type `parent` cannot be part of an intersection type', 'intersection_type_parent_not_allowed.php');
     }
 
     public function testStaticCannotBePartOfIntersectionType()
     {
-        $this->exec("Type 'static' cannot be part of an intersection type", 'intersection_type_static_not_allowed.php');
+        $this->exec('Type `static` cannot be part of an intersection type', 'intersection_type_static_not_allowed.php');
     }
 
     public function testConstructorCannotDeclareReturnType()

--- a/phpunit/src/CompoundTypeValidationTest.php
+++ b/phpunit/src/CompoundTypeValidationTest.php
@@ -59,6 +59,51 @@ class CompoundTypeValidationTest extends BaseTest
         $this->exec('Duplicate type `Ix` is redundant', 'type_rule_intersect_dup.php');
     }
 
+    public function testSelfCannotJoinBareIntersection(): void
+    {
+        $this->exec('Type `self` cannot be part of an intersection type', 'type_rule_self_intersect_method.php');
+    }
+
+    public function testSelfCannotJoinDnfIntersection(): void
+    {
+        $this->exec('Type `self` cannot be part of an intersection type', 'type_rule_self_dnf_method.php');
+    }
+
+    public function testParentCannotJoinDnfIntersection(): void
+    {
+        $this->exec('Type `parent` cannot be part of an intersection type', 'type_rule_parent_dnf_method.php');
+    }
+
+    public function testStaticCannotJoinBareIntersectionReturn(): void
+    {
+        $this->exec('Type `static` cannot be part of an intersection type', 'type_rule_static_intersect_return.php');
+    }
+
+    public function testStaticCannotJoinDnfIntersectionReturn(): void
+    {
+        $this->exec('Type `static` cannot be part of an intersection type', 'type_rule_static_dnf_return.php');
+    }
+
+    public function testSelfCannotJoinDnfIntersectionInProperty(): void
+    {
+        $this->exec('Type `self` cannot be part of an intersection type', 'type_rule_self_dnf_property.php');
+    }
+
+    public function testParentCannotJoinDnfIntersectionInConstant(): void
+    {
+        $this->exec('Type `parent` cannot be part of an intersection type', 'type_rule_parent_dnf_const.php');
+    }
+
+    public function testSelfCannotJoinDnfIntersectionInPromotedParam(): void
+    {
+        $this->exec('Type `self` cannot be part of an intersection type', 'type_rule_self_dnf_promoted.php');
+    }
+
+    public function testClassScopeKeywordBesideDnfGroupStillCompiles(): void
+    {
+        $this->compile('type_rule_keyword_beside_dnf_valid.php');
+    }
+
     public function testObjectWithClassTypeIsRedundant(): void
     {
         $this->exec(

--- a/phpunit/src/CompoundTypeValidationTest.php
+++ b/phpunit/src/CompoundTypeValidationTest.php
@@ -229,4 +229,54 @@ class CompoundTypeValidationTest extends BaseTest
     {
         $this->compile('type_rule_scope_valid.php');
     }
+
+    /*
+     * Closure and arrow-function signatures inside function bodies are only
+     * resolved during conversion, so they exercise the compound rules on the
+     * shared parseTypeDecl() path rather than through the preprocessor.
+     */
+
+    public function testClosureDuplicateUnionMemberIsRejected(): void
+    {
+        $this->exec('Duplicate type `int` is redundant', 'type_rule_closure_dup_union.php');
+    }
+
+    public function testArrowFunctionDuplicateUnionMemberIsRejected(): void
+    {
+        $this->exec('Duplicate type `int` is redundant', 'type_rule_arrow_dup_union.php');
+    }
+
+    public function testClosureScalarCannotJoinIntersection(): void
+    {
+        $this->exec('Type `int` cannot be part of an intersection type', 'type_rule_closure_intersect_scalar.php');
+    }
+
+    public function testClosureCallableCannotJoinDnfIntersection(): void
+    {
+        $this->exec('Type callable cannot be part of an intersection type', 'type_rule_closure_callable_dnf.php');
+    }
+
+    public function testClosurePermutedDnfGroupIsRedundant(): void
+    {
+        $this->exec('Type `B&A` is redundant with type `A&B`', 'type_rule_closure_dnf_permuted.php');
+    }
+
+    public function testGlobalClosureSelfCannotJoinIntersection(): void
+    {
+        // Zend rejects class-scope keywords inside an intersection even in a
+        // global closure that could later be bound to a class scope.
+        $this->exec('Type `self` cannot be part of an intersection type', 'type_rule_closure_self_intersect_global.php');
+    }
+
+    public function testGlobalClosureMayDeclareSelfType(): void
+    {
+        // Zend compiles a global closure declaring self: the closure may be
+        // bound to a class scope before it is ever called.
+        $this->compile('type_rule_closure_self_return_valid.php');
+    }
+
+    public function testGlobalClosureMayDeclareStaticReturn(): void
+    {
+        $this->compile('type_rule_closure_static_return_valid.php');
+    }
 }

--- a/phpunit/src/CompoundTypeValidationTest.php
+++ b/phpunit/src/CompoundTypeValidationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Compound type well-formedness, shared across parameters, returns,
+ * properties, and constants: duplicate members, bool/true/false
+ * overlap, standalone-only types, nullable restrictions, intersection
+ * member rules, class-scope type keywords, and duplicate implements.
+ */
+class CompoundTypeValidationTest extends BaseTest
+{
+    public function testDuplicateUnionMemberIsRejected(): void
+    {
+        $this->exec('Duplicate type `int` is redundant', 'type_rule_dup_union.php');
+    }
+
+    public function testDuplicateClassUnionMemberIsRejected(): void
+    {
+        $this->exec('Duplicate type `Foo` is redundant', 'type_rule_dup_class_union.php');
+    }
+
+    public function testBoolWithFalseIsRedundant(): void
+    {
+        $this->exec('Duplicate type `false` is redundant', 'type_rule_bool_false.php');
+    }
+
+    public function testTrueWithFalseMustUseBool(): void
+    {
+        $this->exec('Type contains both `true` and `false`, `bool` must be used instead', 'type_rule_true_false.php');
+    }
+
+    public function testMixedCannotBeUnionMember(): void
+    {
+        $this->exec('Type `mixed` can only be used as a standalone type', 'type_rule_mixed_union.php');
+    }
+
+    public function testMixedCannotBeNullable(): void
+    {
+        $this->exec('Type `mixed` cannot be marked as nullable since mixed already includes null', 'type_rule_nullable_mixed.php');
+    }
+
+    public function testVoidCannotBeUnionMember(): void
+    {
+        $this->exec('Type `void` can only be used as a standalone type', 'type_rule_void_union.php');
+    }
+
+    public function testIterableExpansionDetectsArrayDuplicate(): void
+    {
+        $this->exec('Duplicate type `array` is redundant', 'type_rule_iterable_array.php');
+    }
+
+    public function testScalarCannotJoinIntersection(): void
+    {
+        $this->exec('Type `int` cannot be part of an intersection type', 'type_rule_intersect_scalar.php');
+    }
+
+    public function testDuplicateIntersectionMemberIsRejected(): void
+    {
+        $this->exec('Duplicate type `Ix` is redundant', 'type_rule_intersect_dup.php');
+    }
+
+    public function testStaticReturnRequiresClassScope(): void
+    {
+        $this->exec('Cannot use "static" when no class scope is active', 'type_rule_static_return_global.php');
+    }
+
+    public function testSelfReturnRequiresClassScope(): void
+    {
+        $this->exec('Cannot use "self" when no class scope is active', 'type_rule_self_return_global.php');
+    }
+
+    public function testDuplicateImplementsIsRejected(): void
+    {
+        $this->exec('Class `C` cannot implement previously implemented interface `Ia`', 'type_rule_implements_dup.php');
+    }
+
+    public function testWellFormedCompoundTypesStillCompile(): void
+    {
+        $this->compile('type_rule_valid.php');
+    }
+}

--- a/phpunit/src/CompoundTypeValidationTest.php
+++ b/phpunit/src/CompoundTypeValidationTest.php
@@ -4,7 +4,8 @@
  * Compound type well-formedness, shared across parameters, returns,
  * properties, and constants: duplicate members, bool/true/false
  * overlap, standalone-only types, nullable restrictions, intersection
- * member rules, class-scope type keywords, and duplicate implements.
+ * member rules, whole-DNF redundancy, `object` absorbing class types,
+ * class-scope type keywords, and duplicate implements.
  */
 class CompoundTypeValidationTest extends BaseTest
 {
@@ -58,14 +59,115 @@ class CompoundTypeValidationTest extends BaseTest
         $this->exec('Duplicate type `Ix` is redundant', 'type_rule_intersect_dup.php');
     }
 
+    public function testObjectWithClassTypeIsRedundant(): void
+    {
+        $this->exec(
+            'Type `Foo|object` contains both object and a class type, which is redundant',
+            'type_rule_object_class_union.php',
+        );
+    }
+
+    public function testObjectWithClassTypeIsRedundantInEitherOrder(): void
+    {
+        $this->exec(
+            'Type `Foo|object` contains both object and a class type, which is redundant',
+            'type_rule_object_class_union_reversed.php',
+        );
+    }
+
+    public function testObjectWithInterfaceTypeIsRedundant(): void
+    {
+        $this->exec(
+            'Type `Ifc|object` contains both object and a class type, which is redundant',
+            'type_rule_object_interface_union.php',
+        );
+    }
+
+    public function testObjectWithDnfGroupIsRedundant(): void
+    {
+        $this->exec(
+            'Type `(A&B)|object` contains both object and a class type, which is redundant',
+            'type_rule_object_dnf_union.php',
+        );
+    }
+
+    public function testPermutedDnfGroupIsRedundant(): void
+    {
+        $this->exec('Type `B&A` is redundant with type `A&B`', 'type_rule_dnf_permuted.php');
+    }
+
+    public function testDnfGroupMoreRestrictiveThanPlainMemberIsRedundant(): void
+    {
+        $this->exec(
+            'Type `A&B` is redundant as it is more restrictive than type `A`',
+            'type_rule_dnf_subset.php',
+        );
+    }
+
+    public function testDnfGroupMoreRestrictiveThanPlainMemberIsRedundantInEitherOrder(): void
+    {
+        $this->exec(
+            'Type `A&B` is redundant as it is more restrictive than type `A`',
+            'type_rule_dnf_subset_reversed.php',
+        );
+    }
+
+    public function testDnfSupersetGroupIsRedundant(): void
+    {
+        $this->exec(
+            'Type `A&B&C2` is redundant as it is more restrictive than type `A&B`',
+            'type_rule_dnf_superset_group.php',
+        );
+    }
+
     public function testStaticReturnRequiresClassScope(): void
     {
         $this->exec('Cannot use "static" when no class scope is active', 'type_rule_static_return_global.php');
     }
 
+    public function testStaticUnionReturnRequiresClassScope(): void
+    {
+        $this->exec('Cannot use "static" when no class scope is active', 'type_rule_static_union_return_global.php');
+    }
+
     public function testSelfReturnRequiresClassScope(): void
     {
         $this->exec('Cannot use "self" when no class scope is active', 'type_rule_self_return_global.php');
+    }
+
+    public function testSelfParameterRequiresClassScope(): void
+    {
+        $this->exec('Cannot use "self" when no class scope is active', 'type_rule_self_param_global.php');
+    }
+
+    public function testSelfUnionReturnRequiresClassScope(): void
+    {
+        $this->exec('Cannot use "self" when no class scope is active', 'type_rule_self_union_return_global.php');
+    }
+
+    public function testSelfNullableParameterRequiresClassScope(): void
+    {
+        $this->exec('Cannot use "self" when no class scope is active', 'type_rule_self_nullable_param_global.php');
+    }
+
+    public function testSelfDnfParameterRequiresClassScope(): void
+    {
+        $this->exec('Cannot use "self" when no class scope is active', 'type_rule_self_dnf_param_global.php');
+    }
+
+    public function testParentParameterRequiresClassScope(): void
+    {
+        $this->exec('Cannot use "parent" when no class scope is active', 'type_rule_parent_param_global.php');
+    }
+
+    public function testParentParameterRequiresParentClass(): void
+    {
+        $this->exec('Cannot use "parent" when current class scope has no parent', 'type_rule_parent_no_parent_method.php');
+    }
+
+    public function testParentPropertyRequiresParentClass(): void
+    {
+        $this->exec('Cannot use "parent" when current class scope has no parent', 'type_rule_parent_no_parent_property.php');
     }
 
     public function testDuplicateImplementsIsRejected(): void
@@ -76,5 +178,10 @@ class CompoundTypeValidationTest extends BaseTest
     public function testWellFormedCompoundTypesStillCompile(): void
     {
         $this->compile('type_rule_valid.php');
+    }
+
+    public function testClassScopeKeywordsInsideClassLikeScopesStillCompile(): void
+    {
+        $this->compile('type_rule_scope_valid.php');
     }
 }

--- a/src/Generator/TypeCheckGenerator.php
+++ b/src/Generator/TypeCheckGenerator.php
@@ -159,7 +159,7 @@ trait TypeCheckGenerator
             foreach ($typeNode->types as $subType) {
                 $nameLower = strtolower($this->parseIdentifier($subType));
                 if ($nameLower === 'self' || $nameLower === 'parent' || $nameLower === 'static') {
-                    $this->fatalError($subType, "Type '{$nameLower}' cannot be part of an intersection type");
+                    $this->fatalError($subType, "Type `{$nameLower}` cannot be part of an intersection type");
                 }
             }
             $clause = $this->buildTypeCheckClause($typeNode);

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -998,14 +998,15 @@ class Preprocessor extends CompilerBase
                 $returnTypeKeyword = $rtLower;
             }
         }
-        // `self`/`static` return types need a class scope; Zend rejects them
-        // on free functions at compile time. `parent` is already rejected in
-        // parseTypeDecl for every declaration context.
-        if (($returnTypeKeyword === 'self' || $returnTypeKeyword === 'static')
-            && $v instanceof Node\Stmt\Function_
-            && $this->classDef === null
-        ) {
-            $this->fatalError($v->returnType, "Cannot use \"{$returnTypeKeyword}\" when no class scope is active");
+        // Class-scope type keywords need an active class scope, in every
+        // declaration context and at any nesting depth. Methods always have
+        // one (class, interface, trait, enum); a free function never does,
+        // no matter where it is declared.
+        $classScope = $v instanceof Node\Stmt\ClassMethod;
+        $scopeHasParent = $classScope && $this->currentClassScopeHasParent();
+        $this->validateClassScopeTypeKeywords($v->returnType, $classScope, $scopeHasParent);
+        foreach ($v->params as $param) {
+            $this->validateClassScopeTypeKeywords($param->type, $classScope, $scopeHasParent);
         }
         [$returnType, $class] = $this->resolveTypeDecl($v->returnType, self::DECL_TYPE_OF_RETURN);
         $this->assertSupportedNativeObjectTypeNode($v->returnType, self::DECL_TYPE_OF_RETURN, $v);
@@ -1598,6 +1599,7 @@ class Preprocessor extends CompilerBase
     {
         $this->resetFunction();
         $flags = $this->parseModifiers($v->flags);
+        $this->validateClassScopeTypeKeywords($v->type, true, $this->currentClassScopeHasParent());
         [$declaredType, $class] = $v->type
             ? $this->resolveTypeDecl($v->type, self::DECL_TYPE_OF_CONST)
             : [null, ''];
@@ -1751,6 +1753,7 @@ class Preprocessor extends CompilerBase
         // Resolving the declaration also runs the common compound-type
         // validation (callable as an intersection/DNF member is rejected
         // there, ahead of the property-specific rule, matching Zend).
+        $this->validateClassScopeTypeKeywords($typeNode, true, $this->currentClassScopeHasParent());
         [$type, $class] = $this->resolveTypeDecl($typeNode, self::DECL_TYPE_OF_PROPERTY);
         // `callable` is a runtime-context type (a string or array may or may
         // not be callable depending on scope), so Zend forbids it in property
@@ -1846,9 +1849,11 @@ class Preprocessor extends CompilerBase
      * Compile-time well-formedness of compound type declarations, mirroring
      * Zend: standalone-only types inside unions, invalid nullable targets,
      * duplicate members (after alias/namespace resolution, with iterable
-     * expanded to array|Traversable), the bool/true/false overlaps, and
-     * non-class standard types inside intersections. Redundancy between whole
-     * DNF groups is not checked.
+     * expanded to array|Traversable), the bool/true/false overlaps,
+     * non-class standard types inside intersections, redundancy between
+     * whole DNF groups (a repeated member set in any order, or a group
+     * strictly more restrictive than another group or plain class member),
+     * and `object` absorbing every class type.
      */
     private function validateCompoundTypeDecl(?NodeAbstract $type): void
     {
@@ -1885,10 +1890,23 @@ class Preprocessor extends CompilerBase
             }
             $seen[$key] = true;
         };
+        // Rendered like Zend's zend_type_to_string(): class types keep their
+        // source order in front, standard types follow in a fixed order.
+        $classish = [];
+        $builtins = [];
+        $hasObject = false;
+        $hasClassType = false;
+        // Every DNF group and plain class member, as a canonical member set,
+        // for Zend's whole-list redundancy comparison.
+        $groups = [];
         foreach ($type->types as $member) {
             if ($member instanceof IntersectionType) {
                 // A DNF group: its members obey the intersection rules.
-                $this->validateIntersectionTypeDecl($member);
+                $groupMembers = $this->validateIntersectionTypeDecl($member);
+                $display = implode('&', $groupMembers);
+                $classish[] = '(' . $display . ')';
+                $hasClassType = true;
+                $groups[] = [array_keys($groupMembers), $display, $member];
                 continue;
             }
             $name = $this->parseIdentifier($member);
@@ -1914,30 +1932,86 @@ class Preprocessor extends CompilerBase
                     $this->fatalError($member, "Duplicate type `{$nameLower}` is redundant");
                 }
                 $addMember($nameLower, $nameLower, $member);
+                $builtins[] = $nameLower;
                 continue;
             }
             if ($nameLower === 'iterable') {
                 // Zend expands iterable to array|Traversable before the
                 // redundancy check and reports the overlapping component.
+                // The expansion alone does not count as a class type for the
+                // object-redundancy rule.
                 $addMember('iterable', 'iterable', $member);
                 $addMember('array', 'array', $member);
                 $addMember('traversable', 'Traversable', $member);
+                $classish[] = 'Traversable';
+                $builtins[] = 'array';
                 continue;
             }
-            if (isset($this->zendTypeMap[$nameLower])
-                || in_array($nameLower, ['self', 'parent', 'static'], true)
-            ) {
+            if (isset($this->zendTypeMap[$nameLower])) {
                 $addMember($nameLower, $nameLower, $member);
+                if ($nameLower === 'object') {
+                    $hasObject = true;
+                } else {
+                    $builtins[] = $nameLower;
+                }
+                continue;
+            }
+            if (in_array($nameLower, ['self', 'parent', 'static'], true)) {
+                $addMember($nameLower, $nameLower, $member);
+                $classish[] = $nameLower;
+                $hasClassType = true;
                 continue;
             }
             $resolved = $member instanceof Node\Name\FullyQualified
                 ? $member->toString()
                 : $this->getNamespacedClassName($name);
             $addMember(strtolower($resolved), $resolved, $member);
+            $classish[] = $resolved;
+            $hasClassType = true;
+            $groups[] = [[strtolower($resolved)], $resolved, $member];
+        }
+
+        // Whole-DNF redundancy: Zend compares every pair of intersection
+        // groups and plain class members as canonical member sets. An equal
+        // set in any member order is a repeat; a strict superset is redundant
+        // because it is more restrictive than the smaller type it can never
+        // widen: (A&B)|(B&A), (A&B)|A and A|(A&B) are all rejected.
+        $groupCount = count($groups);
+        for ($i = 0; $i < $groupCount; $i++) {
+            for ($j = $i + 1; $j < $groupCount; $j++) {
+                [$setI, $displayI] = $groups[$i];
+                [$setJ, $displayJ, $nodeJ] = $groups[$j];
+                if (count($setI) === count($setJ)) {
+                    if (array_diff($setI, $setJ) === []) {
+                        $this->fatalError($nodeJ, "Type `{$displayJ}` is redundant with type `{$displayI}`");
+                    }
+                } elseif (count($setI) > count($setJ)) {
+                    if (array_diff($setJ, $setI) === []) {
+                        $this->fatalError($groups[$i][2], "Type `{$displayI}` is redundant as it is more restrictive than type `{$displayJ}`");
+                    }
+                } elseif (array_diff($setI, $setJ) === []) {
+                    $this->fatalError($nodeJ, "Type `{$displayJ}` is redundant as it is more restrictive than type `{$displayI}`");
+                }
+            }
+        }
+
+        if ($hasObject && $hasClassType) {
+            // `object` already accepts every object: naming a class type
+            // (including self/parent/static and DNF groups) beside it is
+            // redundant. Zend rejects the whole declared type.
+            $order = array_flip(['callable', 'object', 'array', 'string', 'int', 'float', 'bool', 'false', 'true', 'null']);
+            $builtins[] = 'object';
+            usort($builtins, static fn (string $a, string $b): int => ($order[$a] ?? 99) <=> ($order[$b] ?? 99));
+            $typeStr = implode('|', array_merge($classish, $builtins));
+            $this->fatalError($type, "Type `{$typeStr}` contains both object and a class type, which is redundant");
         }
     }
 
-    private function validateIntersectionTypeDecl(IntersectionType $type): void
+    /**
+     * @return array<string, string> resolved member names in declaration
+     *                               order, keyed by their lowercase form
+     */
+    private function validateIntersectionTypeDecl(IntersectionType $type): array
     {
         $seen = [];
         foreach ($type->types as $member) {
@@ -1961,8 +2035,65 @@ class Preprocessor extends CompilerBase
             if (isset($seen[$resolvedLower])) {
                 $this->fatalError($member, "Duplicate type `{$resolved}` is redundant");
             }
-            $seen[$resolvedLower] = true;
+            $seen[$resolvedLower] = $resolved;
         }
+        return $seen;
+    }
+
+    /**
+     * Zend rejects class-scope type keywords at compile time in every
+     * declaration context and at any nesting depth (nullable, union,
+     * intersection, DNF): `self`, `parent`, and `static` need an active
+     * class scope, and `parent` additionally needs that scope to have a
+     * parent class. A free function never has a class scope, no matter
+     * where it is declared; traits keep `parent` late-bound until the
+     * consuming class is known. (`static` outside a return type never
+     * reaches the compiler: PHP's grammar rejects it in parameter and
+     * property types, and class-constant types — where Zend accepts it —
+     * always have a class scope.)
+     */
+    private function validateClassScopeTypeKeywords(?NodeAbstract $type, bool $classScope, bool $hasParent): void
+    {
+        if ($type === null) {
+            return;
+        }
+        if ($type instanceof NullableType) {
+            $this->validateClassScopeTypeKeywords($type->type, $classScope, $hasParent);
+            return;
+        }
+        if ($type instanceof UnionType || $type instanceof IntersectionType) {
+            foreach ($type->types as $member) {
+                $this->validateClassScopeTypeKeywords($member, $classScope, $hasParent);
+            }
+            return;
+        }
+        if (!$type instanceof Node\Identifier && !$type instanceof Node\Name) {
+            return;
+        }
+        $nameLower = strtolower($this->parseIdentifier($type));
+        if (!in_array($nameLower, ['self', 'parent', 'static'], true)) {
+            return;
+        }
+        if (!$classScope) {
+            $this->fatalError($type, "Cannot use \"{$nameLower}\" when no class scope is active");
+        }
+        if ($nameLower === 'parent' && !$hasParent) {
+            $this->fatalError($type, 'Cannot use "parent" when current class scope has no parent');
+        }
+    }
+
+    /**
+     * Whether `parent` may appear in a type declared in the current
+     * class-like scope: the class has a parent, or the scope is a trait
+     * where `parent` stays late-bound until the consuming class is known.
+     * Interfaces and enums never have a parent class.
+     */
+    private function currentClassScopeHasParent(): bool
+    {
+        if ($this->classDef === null) {
+            return false;
+        }
+        return $this->classDef->trait !== null || $this->classDef->extends !== '';
     }
 
     /**
@@ -2722,6 +2853,9 @@ class Preprocessor extends CompilerBase
                         );
                     }
                     if ($stmt->type) {
+                        // Interface constants have a class scope but never a
+                        // parent class, matching Zend.
+                        $this->validateClassScopeTypeKeywords($stmt->type, true, false);
                         [$type, $class] = $this->resolveTypeDecl($stmt->type, self::DECL_TYPE_OF_CONST);
                         if ($this->typeDeclContainsCallable($stmt->type)) {
                             $this->fatalError(
@@ -2858,6 +2992,8 @@ class Preprocessor extends CompilerBase
             }
         }
 
+        // Interface properties have a class scope but never a parent class.
+        $this->validateClassScopeTypeKeywords($property->type, true, false);
         [$type, $class] = $this->resolveTypeDecl($property->type, self::DECL_TYPE_OF_PROPERTY);
         $nullable = $property->type instanceof NullableType;
         foreach ($property->props as $prop) {

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -998,6 +998,15 @@ class Preprocessor extends CompilerBase
                 $returnTypeKeyword = $rtLower;
             }
         }
+        // `self`/`static` return types need a class scope; Zend rejects them
+        // on free functions at compile time. `parent` is already rejected in
+        // parseTypeDecl for every declaration context.
+        if (($returnTypeKeyword === 'self' || $returnTypeKeyword === 'static')
+            && $v instanceof Node\Stmt\Function_
+            && $this->classDef === null
+        ) {
+            $this->fatalError($v->returnType, "Cannot use \"{$returnTypeKeyword}\" when no class scope is active");
+        }
         [$returnType, $class] = $this->resolveTypeDecl($v->returnType, self::DECL_TYPE_OF_RETURN);
         $this->assertSupportedNativeObjectTypeNode($v->returnType, self::DECL_TYPE_OF_RETURN, $v);
         $nullableNativeReturn = $this->resolveNullableNativeObjectType(
@@ -1278,6 +1287,19 @@ class Preprocessor extends CompilerBase
         }
         if (!$class instanceof Node\Stmt\Trait_) {
             $this->classDef->implements = $this->parseImplements($class->implements);
+            $implemented = [];
+            foreach ($this->classDef->implements as $i => $interfaceName) {
+                $interfaceLower = strtolower($interfaceName);
+                $errorNode = $class->implements[$i] ?? $class;
+                if (isset($implemented[$interfaceLower])) {
+                    $kind = $class instanceof Node\Stmt\Enum_ ? 'Enum' : 'Class';
+                    $this->fatalError(
+                        $errorNode,
+                        "{$kind} `{$fullClassName}` cannot implement previously implemented interface `{$interfaceName}`",
+                    );
+                }
+                $implemented[$interfaceLower] = true;
+            }
         } else {
             $this->classDef->trait = $class;
             // Trait members are compiled later in the consuming class, but
@@ -1808,6 +1830,145 @@ class Preprocessor extends CompilerBase
         $this->classDef->properties[$name] = $propDef;
         return $propDef;
     }
+
+    /**
+     * Validate compound well-formedness before resolving, so every context a
+     * type declaration is parsed in (parameters, returns, properties, class
+     * and interface constants, closures) shares the same Zend rules.
+     */
+    protected function resolveTypeDecl(?NodeAbstract $type, int $what): array
+    {
+        $this->validateCompoundTypeDecl($type);
+        return parent::resolveTypeDecl($type, $what);
+    }
+
+    /**
+     * Compile-time well-formedness of compound type declarations, mirroring
+     * Zend: standalone-only types inside unions, invalid nullable targets,
+     * duplicate members (after alias/namespace resolution, with iterable
+     * expanded to array|Traversable), the bool/true/false overlaps, and
+     * non-class standard types inside intersections. Redundancy between whole
+     * DNF groups is not checked.
+     */
+    private function validateCompoundTypeDecl(?NodeAbstract $type): void
+    {
+        if ($type instanceof NullableType) {
+            $inner = $type->type;
+            if (!$inner instanceof Node\Identifier && !$inner instanceof Node\Name) {
+                return;
+            }
+            $innerLower = strtolower($this->parseIdentifier($inner));
+            if ($innerLower === 'mixed') {
+                $this->fatalError($type, 'Type `mixed` cannot be marked as nullable since mixed already includes null');
+            }
+            if ($innerLower === 'null') {
+                $this->fatalError($type, '`null` cannot be marked as nullable');
+            }
+            if ($innerLower === 'void' || $innerLower === 'never') {
+                $this->fatalError($type, "Type `{$innerLower}` can only be used as a standalone type");
+            }
+            return;
+        }
+        if ($type instanceof UnionType) {
+            $this->validateUnionTypeDecl($type);
+        } elseif ($type instanceof IntersectionType) {
+            $this->validateIntersectionTypeDecl($type);
+        }
+    }
+
+    private function validateUnionTypeDecl(UnionType $type): void
+    {
+        $seen = [];
+        $addMember = function (string $key, string $display, NodeAbstract $node) use (&$seen): void {
+            if (isset($seen[$key])) {
+                $this->fatalError($node, "Duplicate type `{$display}` is redundant");
+            }
+            $seen[$key] = true;
+        };
+        foreach ($type->types as $member) {
+            if ($member instanceof IntersectionType) {
+                // A DNF group: its members obey the intersection rules.
+                $this->validateIntersectionTypeDecl($member);
+                continue;
+            }
+            $name = $this->parseIdentifier($member);
+            $nameLower = strtolower($name);
+            if ($nameLower === 'mixed' || $nameLower === 'void' || $nameLower === 'never') {
+                $this->fatalError($member, "Type `{$nameLower}` can only be used as a standalone type");
+            }
+            if ($nameLower === 'bool' || $nameLower === 'false' || $nameLower === 'true') {
+                // Zend folds false/true into bool: a union may not repeat the
+                // overlap, and naming both literals asks for bool instead.
+                if (($nameLower === 'true' && isset($seen['false']))
+                    || ($nameLower === 'false' && isset($seen['true']))
+                ) {
+                    $this->fatalError($member, 'Type contains both `true` and `false`, `bool` must be used instead');
+                }
+                if ($nameLower === 'bool') {
+                    foreach (['false', 'true'] as $literal) {
+                        if (isset($seen[$literal])) {
+                            $this->fatalError($member, "Duplicate type `{$literal}` is redundant");
+                        }
+                    }
+                } elseif (isset($seen['bool'])) {
+                    $this->fatalError($member, "Duplicate type `{$nameLower}` is redundant");
+                }
+                $addMember($nameLower, $nameLower, $member);
+                continue;
+            }
+            if ($nameLower === 'iterable') {
+                // Zend expands iterable to array|Traversable before the
+                // redundancy check and reports the overlapping component.
+                $addMember('iterable', 'iterable', $member);
+                $addMember('array', 'array', $member);
+                $addMember('traversable', 'Traversable', $member);
+                continue;
+            }
+            if (isset($this->zendTypeMap[$nameLower])
+                || in_array($nameLower, ['self', 'parent', 'static'], true)
+            ) {
+                $addMember($nameLower, $nameLower, $member);
+                continue;
+            }
+            $resolved = $member instanceof Node\Name\FullyQualified
+                ? $member->toString()
+                : $this->getNamespacedClassName($name);
+            $addMember(strtolower($resolved), $resolved, $member);
+        }
+    }
+
+    private function validateIntersectionTypeDecl(IntersectionType $type): void
+    {
+        $seen = [];
+        foreach ($type->types as $member) {
+            $name = $this->parseIdentifier($member);
+            $nameLower = strtolower($name);
+            if ($nameLower === 'self' || $nameLower === 'parent' || $nameLower === 'static') {
+                // Rejected later by buildTypeCheckFromNode with its
+                // established "cannot be part of an intersection type" text.
+                continue;
+            }
+            if (in_array($nameLower, [
+                'int', 'float', 'bool', 'false', 'true', 'string', 'array',
+                'object', 'mixed', 'null', 'void', 'never', 'callable', 'iterable',
+            ], true)) {
+                $this->fatalError($member, "Type `{$nameLower}` cannot be part of an intersection type");
+            }
+            $resolved = $member instanceof Node\Name\FullyQualified
+                ? $member->toString()
+                : $this->getNamespacedClassName($name);
+            $resolvedLower = strtolower($resolved);
+            if (isset($seen[$resolvedLower])) {
+                $this->fatalError($member, "Duplicate type `{$resolved}` is redundant");
+            }
+            $seen[$resolvedLower] = true;
+        }
+    }
+
+    /**
+     * Whether a declared type mentions `callable` outside an intersection.
+     * Zend forbids callable in property and class-constant types; members of
+     * an intersection are rejected separately as non-class types.
 
     /**
      * Whether a declared type mentions `callable` outside an intersection.

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -1835,218 +1835,6 @@ class Preprocessor extends CompilerBase
     }
 
     /**
-     * Validate compound well-formedness before resolving, so every context a
-     * type declaration is parsed in (parameters, returns, properties, class
-     * and interface constants, closures) shares the same Zend rules.
-     */
-    protected function resolveTypeDecl(?NodeAbstract $type, int $what): array
-    {
-        $this->validateCompoundTypeDecl($type);
-        return parent::resolveTypeDecl($type, $what);
-    }
-
-    /**
-     * Compile-time well-formedness of compound type declarations, mirroring
-     * Zend: standalone-only types inside unions, invalid nullable targets,
-     * duplicate members (after alias/namespace resolution, with iterable
-     * expanded to array|Traversable), the bool/true/false overlaps,
-     * non-class standard types and class-scope keywords (self, parent,
-     * static) inside intersections, whether bare or DNF, redundancy between
-     * whole DNF groups (a repeated member set in any order, or a group
-     * strictly more restrictive than another group or plain class member),
-     * and `object` absorbing every class type.
-     */
-    private function validateCompoundTypeDecl(?NodeAbstract $type): void
-    {
-        if ($type instanceof NullableType) {
-            $inner = $type->type;
-            if (!$inner instanceof Node\Identifier && !$inner instanceof Node\Name) {
-                return;
-            }
-            $innerLower = strtolower($this->parseIdentifier($inner));
-            if ($innerLower === 'mixed') {
-                $this->fatalError($type, 'Type `mixed` cannot be marked as nullable since mixed already includes null');
-            }
-            if ($innerLower === 'null') {
-                $this->fatalError($type, '`null` cannot be marked as nullable');
-            }
-            if ($innerLower === 'void' || $innerLower === 'never') {
-                $this->fatalError($type, "Type `{$innerLower}` can only be used as a standalone type");
-            }
-            return;
-        }
-        if ($type instanceof UnionType) {
-            $this->validateUnionTypeDecl($type);
-        } elseif ($type instanceof IntersectionType) {
-            $this->validateIntersectionTypeDecl($type);
-        }
-    }
-
-    private function validateUnionTypeDecl(UnionType $type): void
-    {
-        $seen = [];
-        $addMember = function (string $key, string $display, NodeAbstract $node) use (&$seen): void {
-            if (isset($seen[$key])) {
-                $this->fatalError($node, "Duplicate type `{$display}` is redundant");
-            }
-            $seen[$key] = true;
-        };
-        // Rendered like Zend's zend_type_to_string(): class types keep their
-        // source order in front, standard types follow in a fixed order.
-        $classish = [];
-        $builtins = [];
-        $hasObject = false;
-        $hasClassType = false;
-        // Every DNF group and plain class member, as a canonical member set,
-        // for Zend's whole-list redundancy comparison.
-        $groups = [];
-        foreach ($type->types as $member) {
-            if ($member instanceof IntersectionType) {
-                // A DNF group: its members obey the intersection rules.
-                $groupMembers = $this->validateIntersectionTypeDecl($member);
-                $display = implode('&', $groupMembers);
-                $classish[] = '(' . $display . ')';
-                $hasClassType = true;
-                $groups[] = [array_keys($groupMembers), $display, $member];
-                continue;
-            }
-            $name = $this->parseIdentifier($member);
-            $nameLower = strtolower($name);
-            if ($nameLower === 'mixed' || $nameLower === 'void' || $nameLower === 'never') {
-                $this->fatalError($member, "Type `{$nameLower}` can only be used as a standalone type");
-            }
-            if ($nameLower === 'bool' || $nameLower === 'false' || $nameLower === 'true') {
-                // Zend folds false/true into bool: a union may not repeat the
-                // overlap, and naming both literals asks for bool instead.
-                if (($nameLower === 'true' && isset($seen['false']))
-                    || ($nameLower === 'false' && isset($seen['true']))
-                ) {
-                    $this->fatalError($member, 'Type contains both `true` and `false`, `bool` must be used instead');
-                }
-                if ($nameLower === 'bool') {
-                    foreach (['false', 'true'] as $literal) {
-                        if (isset($seen[$literal])) {
-                            $this->fatalError($member, "Duplicate type `{$literal}` is redundant");
-                        }
-                    }
-                } elseif (isset($seen['bool'])) {
-                    $this->fatalError($member, "Duplicate type `{$nameLower}` is redundant");
-                }
-                $addMember($nameLower, $nameLower, $member);
-                $builtins[] = $nameLower;
-                continue;
-            }
-            if ($nameLower === 'iterable') {
-                // Zend expands iterable to array|Traversable before the
-                // redundancy check and reports the overlapping component.
-                // The expansion alone does not count as a class type for the
-                // object-redundancy rule.
-                $addMember('iterable', 'iterable', $member);
-                $addMember('array', 'array', $member);
-                $addMember('traversable', 'Traversable', $member);
-                $classish[] = 'Traversable';
-                $builtins[] = 'array';
-                continue;
-            }
-            if (isset($this->zendTypeMap[$nameLower])) {
-                $addMember($nameLower, $nameLower, $member);
-                if ($nameLower === 'object') {
-                    $hasObject = true;
-                } else {
-                    $builtins[] = $nameLower;
-                }
-                continue;
-            }
-            if (in_array($nameLower, ['self', 'parent', 'static'], true)) {
-                $addMember($nameLower, $nameLower, $member);
-                $classish[] = $nameLower;
-                $hasClassType = true;
-                continue;
-            }
-            $resolved = $member instanceof Node\Name\FullyQualified
-                ? $member->toString()
-                : $this->getNamespacedClassName($name);
-            $addMember(strtolower($resolved), $resolved, $member);
-            $classish[] = $resolved;
-            $hasClassType = true;
-            $groups[] = [[strtolower($resolved)], $resolved, $member];
-        }
-
-        // Whole-DNF redundancy: Zend compares every pair of intersection
-        // groups and plain class members as canonical member sets. An equal
-        // set in any member order is a repeat; a strict superset is redundant
-        // because it is more restrictive than the smaller type it can never
-        // widen: (A&B)|(B&A), (A&B)|A and A|(A&B) are all rejected.
-        $groupCount = count($groups);
-        for ($i = 0; $i < $groupCount; $i++) {
-            for ($j = $i + 1; $j < $groupCount; $j++) {
-                [$setI, $displayI] = $groups[$i];
-                [$setJ, $displayJ, $nodeJ] = $groups[$j];
-                if (count($setI) === count($setJ)) {
-                    if (array_diff($setI, $setJ) === []) {
-                        $this->fatalError($nodeJ, "Type `{$displayJ}` is redundant with type `{$displayI}`");
-                    }
-                } elseif (count($setI) > count($setJ)) {
-                    if (array_diff($setJ, $setI) === []) {
-                        $this->fatalError($groups[$i][2], "Type `{$displayI}` is redundant as it is more restrictive than type `{$displayJ}`");
-                    }
-                } elseif (array_diff($setI, $setJ) === []) {
-                    $this->fatalError($nodeJ, "Type `{$displayJ}` is redundant as it is more restrictive than type `{$displayI}`");
-                }
-            }
-        }
-
-        if ($hasObject && $hasClassType) {
-            // `object` already accepts every object: naming a class type
-            // (including self/parent/static and DNF groups) beside it is
-            // redundant. Zend rejects the whole declared type.
-            $order = array_flip(['callable', 'object', 'array', 'string', 'int', 'float', 'bool', 'false', 'true', 'null']);
-            $builtins[] = 'object';
-            usort($builtins, static fn (string $a, string $b): int => ($order[$a] ?? 99) <=> ($order[$b] ?? 99));
-            $typeStr = implode('|', array_merge($classish, $builtins));
-            $this->fatalError($type, "Type `{$typeStr}` contains both object and a class type, which is redundant");
-        }
-    }
-
-    /**
-     * @return array<string, string> resolved member names in declaration
-     *                               order, keyed by their lowercase form
-     */
-    private function validateIntersectionTypeDecl(IntersectionType $type): array
-    {
-        $seen = [];
-        foreach ($type->types as $member) {
-            $name = $this->parseIdentifier($member);
-            $nameLower = strtolower($name);
-            if ($nameLower === 'self' || $nameLower === 'parent' || $nameLower === 'static') {
-                // Zend never resolves class-scope keywords inside an
-                // intersection, bare or as a DNF member of a union: the
-                // scope errors ("no class scope", "no parent") take
-                // precedence via validateClassScopeTypeKeywords, then any
-                // surviving keyword is rejected here. buildTypeCheckFromNode
-                // only catches the top-level intersection case, so DNF
-                // members must be rejected at this layer.
-                $this->fatalError($member, "Type `{$nameLower}` cannot be part of an intersection type");
-            }
-            if (in_array($nameLower, [
-                'int', 'float', 'bool', 'false', 'true', 'string', 'array',
-                'object', 'mixed', 'null', 'void', 'never', 'callable', 'iterable',
-            ], true)) {
-                $this->fatalError($member, "Type `{$nameLower}` cannot be part of an intersection type");
-            }
-            $resolved = $member instanceof Node\Name\FullyQualified
-                ? $member->toString()
-                : $this->getNamespacedClassName($name);
-            $resolvedLower = strtolower($resolved);
-            if (isset($seen[$resolvedLower])) {
-                $this->fatalError($member, "Duplicate type `{$resolved}` is redundant");
-            }
-            $seen[$resolvedLower] = $resolved;
-        }
-        return $seen;
-    }
-
-    /**
      * Zend rejects class-scope type keywords at compile time in every
      * declaration context and at any nesting depth (nullable, union,
      * intersection, DNF): `self`, `parent`, and `static` need an active
@@ -2057,6 +1845,14 @@ class Preprocessor extends CompilerBase
      * reaches the compiler: PHP's grammar rejects it in parameter and
      * property types, and class-constant types — where Zend accepts it —
      * always have a class scope.)
+     *
+     * Deliberately applied per declaration context rather than on the shared
+     * parseTypeDecl() path that carries the compound well-formedness rules:
+     * Zend compiles a global closure or arrow function declaring self/static
+     * because it may later be bound to a class scope, so closure signatures
+     * must never run through this check. (Keywords inside an intersection are
+     * still rejected even there — validateIntersectionTypeDecl handles that
+     * on the shared path.)
      */
     private function validateClassScopeTypeKeywords(?NodeAbstract $type, bool $classScope, bool $hasParent): void
     {
@@ -2101,11 +1897,6 @@ class Preprocessor extends CompilerBase
         }
         return $this->classDef->trait !== null || $this->classDef->extends !== '';
     }
-
-    /**
-     * Whether a declared type mentions `callable` outside an intersection.
-     * Zend forbids callable in property and class-constant types; members of
-     * an intersection are rejected separately as non-class types.
 
     /**
      * Whether a declared type mentions `callable` outside an intersection.

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -1850,7 +1850,8 @@ class Preprocessor extends CompilerBase
      * Zend: standalone-only types inside unions, invalid nullable targets,
      * duplicate members (after alias/namespace resolution, with iterable
      * expanded to array|Traversable), the bool/true/false overlaps,
-     * non-class standard types inside intersections, redundancy between
+     * non-class standard types and class-scope keywords (self, parent,
+     * static) inside intersections, whether bare or DNF, redundancy between
      * whole DNF groups (a repeated member set in any order, or a group
      * strictly more restrictive than another group or plain class member),
      * and `object` absorbing every class type.
@@ -2018,9 +2019,14 @@ class Preprocessor extends CompilerBase
             $name = $this->parseIdentifier($member);
             $nameLower = strtolower($name);
             if ($nameLower === 'self' || $nameLower === 'parent' || $nameLower === 'static') {
-                // Rejected later by buildTypeCheckFromNode with its
-                // established "cannot be part of an intersection type" text.
-                continue;
+                // Zend never resolves class-scope keywords inside an
+                // intersection, bare or as a DNF member of a union: the
+                // scope errors ("no class scope", "no parent") take
+                // precedence via validateClassScopeTypeKeywords, then any
+                // surviving keyword is rejected here. buildTypeCheckFromNode
+                // only catches the top-level intersection case, so DNF
+                // members must be rejected at this layer.
+                $this->fatalError($member, "Type `{$nameLower}` cannot be part of an intersection type");
             }
             if (in_array($nameLower, [
                 'int', 'float', 'bool', 'false', 'true', 'string', 'array',

--- a/src/Resolver/NameResolutionTrait.php
+++ b/src/Resolver/NameResolutionTrait.php
@@ -169,6 +169,7 @@ trait NameResolutionTrait
             return Type::VAR;
         }
         $this->assertTypeDeclIntersectionsHaveNoCallable($type);
+        $this->validateCompoundTypeDecl($type);
         if ($type instanceof UnionType || $type instanceof NullableType || $type instanceof IntersectionType) {
             // Complex types are uniformly treated as mixed/var at the static stage; the runtime typeCheck provides the fallback.
             return Type::VAR;
@@ -234,5 +235,219 @@ trait NameResolutionTrait
                 }
             }
         }
+    }
+
+    /**
+     * Compile-time well-formedness of compound type declarations, mirroring
+     * Zend: standalone-only types inside unions, invalid nullable targets,
+     * duplicate members (after alias/namespace resolution, with iterable
+     * expanded to array|Traversable), the bool/true/false overlaps,
+     * non-class standard types and class-scope keywords (self, parent,
+     * static) inside intersections, whether bare or DNF, redundancy between
+     * whole DNF groups (a repeated member set in any order, or a group
+     * strictly more restrictive than another group or plain class member),
+     * and `object` absorbing every class type.
+     *
+     * Lives on the common declaration path in parseTypeDecl() so both
+     * compilation phases share the same rules: preprocessing covers named
+     * functions, methods, properties, and constants, while closure and
+     * arrow-function signatures inside function bodies are only resolved
+     * during conversion. The class-scope keyword rules ("no class scope",
+     * "no parent") deliberately stay out of this path, applied per context
+     * by the preprocessor: Zend compiles a global closure declaring
+     * self/static because it may later be bound to a class scope, yet even
+     * there still rejects those keywords inside an intersection (probed on
+     * 8.4.13), which is why the intersection rule below is unconditional.
+     */
+    private function validateCompoundTypeDecl(?NodeAbstract $type): void
+    {
+        if ($type instanceof NullableType) {
+            $inner = $type->type;
+            if (!$inner instanceof Node\Identifier && !$inner instanceof Node\Name) {
+                return;
+            }
+            $innerLower = strtolower($this->parseIdentifier($inner));
+            if ($innerLower === 'mixed') {
+                $this->fatalError($type, 'Type `mixed` cannot be marked as nullable since mixed already includes null');
+            }
+            if ($innerLower === 'null') {
+                $this->fatalError($type, '`null` cannot be marked as nullable');
+            }
+            if ($innerLower === 'void' || $innerLower === 'never') {
+                $this->fatalError($type, "Type `{$innerLower}` can only be used as a standalone type");
+            }
+            return;
+        }
+        if ($type instanceof UnionType) {
+            $this->validateUnionTypeDecl($type);
+        } elseif ($type instanceof IntersectionType) {
+            $this->validateIntersectionTypeDecl($type);
+        }
+    }
+
+    private function validateUnionTypeDecl(UnionType $type): void
+    {
+        $seen = [];
+        $addMember = function (string $key, string $display, NodeAbstract $node) use (&$seen): void {
+            if (isset($seen[$key])) {
+                $this->fatalError($node, "Duplicate type `{$display}` is redundant");
+            }
+            $seen[$key] = true;
+        };
+        // Rendered like Zend's zend_type_to_string(): class types keep their
+        // source order in front, standard types follow in a fixed order.
+        $classish = [];
+        $builtins = [];
+        $hasObject = false;
+        $hasClassType = false;
+        // Every DNF group and plain class member, as a canonical member set,
+        // for Zend's whole-list redundancy comparison.
+        $groups = [];
+        foreach ($type->types as $member) {
+            if ($member instanceof IntersectionType) {
+                // A DNF group: its members obey the intersection rules.
+                $groupMembers = $this->validateIntersectionTypeDecl($member);
+                $display = implode('&', $groupMembers);
+                $classish[] = '(' . $display . ')';
+                $hasClassType = true;
+                $groups[] = [array_keys($groupMembers), $display, $member];
+                continue;
+            }
+            $name = $this->parseIdentifier($member);
+            $nameLower = strtolower($name);
+            if ($nameLower === 'mixed' || $nameLower === 'void' || $nameLower === 'never') {
+                $this->fatalError($member, "Type `{$nameLower}` can only be used as a standalone type");
+            }
+            if ($nameLower === 'bool' || $nameLower === 'false' || $nameLower === 'true') {
+                // Zend folds false/true into bool: a union may not repeat the
+                // overlap, and naming both literals asks for bool instead.
+                if (($nameLower === 'true' && isset($seen['false']))
+                    || ($nameLower === 'false' && isset($seen['true']))
+                ) {
+                    $this->fatalError($member, 'Type contains both `true` and `false`, `bool` must be used instead');
+                }
+                if ($nameLower === 'bool') {
+                    foreach (['false', 'true'] as $literal) {
+                        if (isset($seen[$literal])) {
+                            $this->fatalError($member, "Duplicate type `{$literal}` is redundant");
+                        }
+                    }
+                } elseif (isset($seen['bool'])) {
+                    $this->fatalError($member, "Duplicate type `{$nameLower}` is redundant");
+                }
+                $addMember($nameLower, $nameLower, $member);
+                $builtins[] = $nameLower;
+                continue;
+            }
+            if ($nameLower === 'iterable') {
+                // Zend expands iterable to array|Traversable before the
+                // redundancy check and reports the overlapping component.
+                // The expansion alone does not count as a class type for the
+                // object-redundancy rule.
+                $addMember('iterable', 'iterable', $member);
+                $addMember('array', 'array', $member);
+                $addMember('traversable', 'Traversable', $member);
+                $classish[] = 'Traversable';
+                $builtins[] = 'array';
+                continue;
+            }
+            if (isset($this->zendTypeMap[$nameLower])) {
+                $addMember($nameLower, $nameLower, $member);
+                if ($nameLower === 'object') {
+                    $hasObject = true;
+                } else {
+                    $builtins[] = $nameLower;
+                }
+                continue;
+            }
+            if (in_array($nameLower, ['self', 'parent', 'static'], true)) {
+                $addMember($nameLower, $nameLower, $member);
+                $classish[] = $nameLower;
+                $hasClassType = true;
+                continue;
+            }
+            $resolved = $member instanceof Node\Name\FullyQualified
+                ? $member->toString()
+                : $this->getNamespacedClassName($name);
+            $addMember(strtolower($resolved), $resolved, $member);
+            $classish[] = $resolved;
+            $hasClassType = true;
+            $groups[] = [[strtolower($resolved)], $resolved, $member];
+        }
+
+        // Whole-DNF redundancy: Zend compares every pair of intersection
+        // groups and plain class members as canonical member sets. An equal
+        // set in any member order is a repeat; a strict superset is redundant
+        // because it is more restrictive than the smaller type it can never
+        // widen: (A&B)|(B&A), (A&B)|A and A|(A&B) are all rejected.
+        $groupCount = count($groups);
+        for ($i = 0; $i < $groupCount; $i++) {
+            for ($j = $i + 1; $j < $groupCount; $j++) {
+                [$setI, $displayI] = $groups[$i];
+                [$setJ, $displayJ, $nodeJ] = $groups[$j];
+                if (count($setI) === count($setJ)) {
+                    if (array_diff($setI, $setJ) === []) {
+                        $this->fatalError($nodeJ, "Type `{$displayJ}` is redundant with type `{$displayI}`");
+                    }
+                } elseif (count($setI) > count($setJ)) {
+                    if (array_diff($setJ, $setI) === []) {
+                        $this->fatalError($groups[$i][2], "Type `{$displayI}` is redundant as it is more restrictive than type `{$displayJ}`");
+                    }
+                } elseif (array_diff($setI, $setJ) === []) {
+                    $this->fatalError($nodeJ, "Type `{$displayJ}` is redundant as it is more restrictive than type `{$displayI}`");
+                }
+            }
+        }
+
+        if ($hasObject && $hasClassType) {
+            // `object` already accepts every object: naming a class type
+            // (including self/parent/static and DNF groups) beside it is
+            // redundant. Zend rejects the whole declared type.
+            $order = array_flip(['callable', 'object', 'array', 'string', 'int', 'float', 'bool', 'false', 'true', 'null']);
+            $builtins[] = 'object';
+            usort($builtins, static fn (string $a, string $b): int => ($order[$a] ?? 99) <=> ($order[$b] ?? 99));
+            $typeStr = implode('|', array_merge($classish, $builtins));
+            $this->fatalError($type, "Type `{$typeStr}` contains both object and a class type, which is redundant");
+        }
+    }
+
+    /**
+     * @return array<string, string> resolved member names in declaration
+     *                               order, keyed by their lowercase form
+     */
+    private function validateIntersectionTypeDecl(IntersectionType $type): array
+    {
+        $seen = [];
+        foreach ($type->types as $member) {
+            $name = $this->parseIdentifier($member);
+            $nameLower = strtolower($name);
+            if ($nameLower === 'self' || $nameLower === 'parent' || $nameLower === 'static') {
+                // Zend never resolves class-scope keywords inside an
+                // intersection, bare or as a DNF member of a union — not
+                // even in a global closure that could later be bound to a
+                // class scope: the scope errors ("no class scope", "no
+                // parent") take precedence via the preprocessor's
+                // validateClassScopeTypeKeywords, then any surviving
+                // keyword is rejected here. buildTypeCheckFromNode only
+                // catches the top-level intersection case, so DNF members
+                // must be rejected at this layer.
+                $this->fatalError($member, "Type `{$nameLower}` cannot be part of an intersection type");
+            }
+            if (in_array($nameLower, [
+                'int', 'float', 'bool', 'false', 'true', 'string', 'array',
+                'object', 'mixed', 'null', 'void', 'never', 'callable', 'iterable',
+            ], true)) {
+                $this->fatalError($member, "Type `{$nameLower}` cannot be part of an intersection type");
+            }
+            $resolved = $member instanceof Node\Name\FullyQualified
+                ? $member->toString()
+                : $this->getNamespacedClassName($name);
+            $resolvedLower = strtolower($resolved);
+            if (isset($seen[$resolvedLower])) {
+                $this->fatalError($member, "Duplicate type `{$resolved}` is redundant");
+            }
+            $seen[$resolvedLower] = $resolved;
+        }
+        return $seen;
     }
 }


### PR DESCRIPTION
Compound type declarations were not validated for well-formedness — all of these compiled, each a Zend compile fatal (probed individually): duplicate union members after alias/namespace resolution (`int|string|int`, `Foo|\Foo`, iterable expanded so `iterable|array` names the overlapping component); bool/true/false overlaps (`bool|false`, `true|false` → "bool must be used instead"); `mixed`/`void`/`never` inside unions; `?mixed`, `?null`, `?void`, `?never`; non-class standard types and duplicates inside intersections; `self`/`static` return types outside class scope (closures exempt, as Zend compiles them); duplicate `implements` entries for classes and enums.

One validation helper runs from a resolveTypeDecl override, so parameters, returns, properties, constants, and closures share the same pass without double-firing. `use T, T` is deliberately still accepted — Zend silently dedupes trait use (probed).

Part of the split of #39.
