### PR TITLE
fix: enforce readonly declaration and inheritance rules

### DIFF
--- a/phpunit/code/inheritance_error_prop_readonly.php
+++ b/phpunit/code/inheritance_error_prop_readonly.php
@@ -6,7 +6,7 @@ class A
 
 class B extends A
 {
-    public readonly int $x = 2;
+    public readonly int $x;
 }
 
 function main() {}

--- a/phpunit/code/readonly_class_allow_dynamic.php
+++ b/phpunit/code/readonly_class_allow_dynamic.php
@@ -1,0 +1,5 @@
+<?php
+#[AllowDynamicProperties]
+readonly class Cfg { public int $port; public function __construct() { $this->port = 80; } }
+
+function main() {}

--- a/phpunit/code/readonly_class_extends.php
+++ b/phpunit/code/readonly_class_extends.php
@@ -1,0 +1,5 @@
+<?php
+readonly class A {}
+class B extends A {}
+
+function main() {}

--- a/phpunit/code/readonly_class_extends_internal.php
+++ b/phpunit/code/readonly_class_extends_internal.php
@@ -1,0 +1,4 @@
+<?php
+readonly class Cfg extends ArrayObject {}
+
+function main() {}

--- a/phpunit/code/readonly_class_extends_rev.php
+++ b/phpunit/code/readonly_class_extends_rev.php
@@ -1,0 +1,5 @@
+<?php
+class A {}
+readonly class B extends A {}
+
+function main() {}

--- a/phpunit/code/readonly_class_extends_valid.php
+++ b/phpunit/code/readonly_class_extends_valid.php
@@ -1,0 +1,5 @@
+<?php
+readonly class A { public function __construct(public int $x) {} }
+readonly class B extends A {}
+
+function main() {}

--- a/phpunit/code/readonly_class_trait_nonreadonly_prop.php
+++ b/phpunit/code/readonly_class_trait_nonreadonly_prop.php
@@ -1,0 +1,5 @@
+<?php
+trait Settings { public int $port; }
+readonly class Cfg { use Settings; }
+
+function main() {}

--- a/phpunit/code/readonly_class_trait_readonly_prop_valid.php
+++ b/phpunit/code/readonly_class_trait_readonly_prop_valid.php
@@ -1,0 +1,5 @@
+<?php
+trait Settings { public readonly int $port; }
+readonly class Cfg { use Settings; public function __construct() { $this->port = 80; } }
+
+function main() {}

--- a/phpunit/code/readonly_class_trait_static_prop.php
+++ b/phpunit/code/readonly_class_trait_static_prop.php
@@ -1,0 +1,5 @@
+<?php
+trait Settings { public static int $port = 80; }
+readonly class Cfg { use Settings; }
+
+function main() {}

--- a/phpunit/code/readonly_rule_class_static.php
+++ b/phpunit/code/readonly_rule_class_static.php
@@ -1,0 +1,4 @@
+<?php
+readonly class Cfg { public static int $port; }
+
+function main() {}

--- a/phpunit/code/readonly_rule_class_untyped.php
+++ b/phpunit/code/readonly_rule_class_untyped.php
@@ -1,0 +1,4 @@
+<?php
+readonly class Cfg { public $port; }
+
+function main() {}

--- a/phpunit/code/readonly_rule_default.php
+++ b/phpunit/code/readonly_rule_default.php
@@ -1,0 +1,4 @@
+<?php
+class Cfg { public readonly int $port = 80; }
+
+function main() {}

--- a/phpunit/code/readonly_rule_promoted_untyped.php
+++ b/phpunit/code/readonly_rule_promoted_untyped.php
@@ -1,0 +1,4 @@
+<?php
+class Cfg { public function __construct(public readonly $port) {} }
+
+function main() {}

--- a/phpunit/code/readonly_rule_static.php
+++ b/phpunit/code/readonly_rule_static.php
@@ -1,0 +1,4 @@
+<?php
+class Cfg { public static readonly int $port; }
+
+function main() {}

--- a/phpunit/code/readonly_rule_untyped.php
+++ b/phpunit/code/readonly_rule_untyped.php
@@ -1,0 +1,4 @@
+<?php
+class Cfg { public readonly $port; }
+
+function main() {}

--- a/phpunit/code/readonly_rule_valid.php
+++ b/phpunit/code/readonly_rule_valid.php
@@ -1,0 +1,4 @@
+<?php
+readonly class Cfg { public int $port; public function __construct(public readonly string $host = "a") { $this->port = 80; } }
+
+function main() {}

--- a/phpunit/src/ClassKindInheritanceTest.php
+++ b/phpunit/src/ClassKindInheritanceTest.php
@@ -27,4 +27,14 @@ class ClassKindInheritanceTest extends BaseTest
     {
         $this->compile('readonly_class_extends_valid.php');
     }
+
+    public function testReadonlyCannotExtendNonReadonlyInternalClass(): void
+    {
+        // Internal parents are not in the symbol table; host reflection
+        // (ReflectionClass::isReadOnly) is authoritative for them.
+        $this->exec(
+            'Readonly class `Cfg` cannot extend non-readonly class `ArrayObject`',
+            'readonly_class_extends_internal.php'
+        );
+    }
 }

--- a/phpunit/src/ClassKindInheritanceTest.php
+++ b/phpunit/src/ClassKindInheritanceTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Readonly-ness is part of the inheritance contract in both directions, and
+ * an interface can only extend other interfaces.
+ */
+class ClassKindInheritanceTest extends BaseTest
+{
+    public function testNonReadonlyCannotExtendReadonly(): void
+    {
+        $this->exec(
+            'Non-readonly class `B` cannot extend readonly class `A`',
+            'readonly_class_extends.php'
+        );
+    }
+
+    public function testReadonlyCannotExtendNonReadonly(): void
+    {
+        $this->exec(
+            'Readonly class `B` cannot extend non-readonly class `A`',
+            'readonly_class_extends_rev.php'
+        );
+    }
+
+
+    public function testReadonlyExtendsReadonlyIsValid(): void
+    {
+        $this->compile('readonly_class_extends_valid.php');
+    }
+}

--- a/phpunit/src/ReadonlyDeclarationRulesTest.php
+++ b/phpunit/src/ReadonlyDeclarationRulesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Zend readonly property declaration rules for ZendVM-backed classes:
+ * no defaults, mandatory type, no static readonly, and the readonly
+ * class modifier applying the same rules to every property.
+ */
+class ReadonlyDeclarationRulesTest extends BaseTest
+{
+    public function testReadonlyPropertyCannotHaveDefault(): void
+    {
+        $this->exec('Readonly property `Cfg::$port` cannot have default value', 'readonly_rule_default.php');
+    }
+
+    public function testReadonlyPropertyMustHaveType(): void
+    {
+        $this->exec('Readonly property `Cfg::$port` must have type', 'readonly_rule_untyped.php');
+    }
+
+    public function testStaticPropertyCannotBeReadonly(): void
+    {
+        $this->exec('Static property `Cfg::$port` cannot be readonly', 'readonly_rule_static.php');
+    }
+
+    public function testPromotedReadonlyParamMustHaveType(): void
+    {
+        $this->exec('Readonly property `Cfg::$port` must have type', 'readonly_rule_promoted_untyped.php');
+    }
+
+    public function testReadonlyClassPropertyMustHaveType(): void
+    {
+        $this->exec('Readonly property `Cfg::$port` must have type', 'readonly_rule_class_untyped.php');
+    }
+
+    public function testReadonlyClassCannotDeclareStaticProperty(): void
+    {
+        $this->exec('Static property `Cfg::$port` cannot be readonly', 'readonly_rule_class_static.php');
+    }
+
+    public function testWellFormedReadonlyDeclarationsStillCompile(): void
+    {
+        // Promoted readonly params may keep a parameter default: it belongs
+        // to the constructor argument, not to the property.
+        $this->compile('readonly_rule_valid.php');
+    }
+}

--- a/phpunit/src/ReadonlyDeclarationRulesTest.php
+++ b/phpunit/src/ReadonlyDeclarationRulesTest.php
@@ -43,4 +43,38 @@ class ReadonlyDeclarationRulesTest extends BaseTest
         // to the constructor argument, not to the property.
         $this->compile('readonly_rule_valid.php');
     }
+
+    public function testReadonlyClassCannotUseTraitWithNonReadonlyProperty(): void
+    {
+        // A trait property keeps its own declaration; the consuming class's
+        // readonly modifier does not upgrade it.
+        $this->exec(
+            'Readonly class `Cfg` cannot use trait with a non-readonly property `Settings::$port`',
+            'readonly_class_trait_nonreadonly_prop.php'
+        );
+    }
+
+    public function testReadonlyClassCannotUseTraitWithStaticProperty(): void
+    {
+        // Static properties can never be readonly, so a trait declaring one
+        // is unusable in a readonly class (Zend reports the same mismatch).
+        $this->exec(
+            'Readonly class `Cfg` cannot use trait with a non-readonly property `Settings::$port`',
+            'readonly_class_trait_static_prop.php'
+        );
+    }
+
+    public function testReadonlyClassUsingTraitWithReadonlyPropertyIsValid(): void
+    {
+        $this->compile('readonly_class_trait_readonly_prop_valid.php');
+    }
+
+    public function testAllowDynamicPropertiesOnReadonlyClassIsRejected(): void
+    {
+        // Dynamic properties and readonly semantics are mutually exclusive.
+        $this->exec(
+            'Cannot apply #[AllowDynamicProperties] to readonly class `Cfg`',
+            'readonly_class_allow_dynamic.php'
+        );
+    }
 }

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -1674,6 +1674,21 @@ class Preprocessor extends CompilerBase
             );
         }
         $flags = $this->parseModifiers($flags);
+        // A `readonly class` marks every property readonly, so the class-level
+        // flag participates in the same Zend declaration rules as an explicit
+        // per-property `readonly` modifier.
+        if (($flags | $this->classDef->flags) & Modifiers::READONLY) {
+            $className = $this->classDef->getNamespacedName(false);
+            if ($flags & Modifiers::STATIC) {
+                $this->fatalError($errorNode, "Static property `{$className}::\${$name}` cannot be readonly");
+            }
+            if ($typeNode === null) {
+                $this->fatalError($errorNode, "Readonly property `{$className}::\${$name}` must have type");
+            }
+            if ($defaultNode !== null) {
+                $this->fatalError($errorNode, "Readonly property `{$className}::\${$name}` cannot have default value");
+            }
+        }
         $this->validateAsymmetricPropertyDeclaration($name, $flags, $typeNode, $errorNode);
         [$type, $class] = $this->resolveTypeDecl($typeNode, self::DECL_TYPE_OF_PROPERTY);
         $this->assertSupportedNativeObjectTypeNode($typeNode, self::DECL_TYPE_OF_PROPERTY, $errorNode);

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -1209,6 +1209,21 @@ class Preprocessor extends CompilerBase
         if (isset($this->symbolDeclInFile[$fullClassNameLower])) {
             $this->fatalError($class, "Duplicate class `{$fullClassName}`");
         }
+        // Dynamic properties and readonly semantics are mutually exclusive:
+        // every property of a readonly class is readonly and declared, so
+        // Zend rejects the attribute at compile time.
+        if ($class instanceof Node\Stmt\Class_ && ($flags & Modifiers::READONLY)) {
+            foreach ($class->attrGroups as $group) {
+                foreach ($group->attrs as $attribute) {
+                    if (strcasecmp($this->getResolvedPhpName($attribute->name), 'AllowDynamicProperties') === 0) {
+                        $this->fatalError(
+                            $attribute,
+                            "Cannot apply #[AllowDynamicProperties] to readonly class `{$fullClassName}`",
+                        );
+                    }
+                }
+            }
+        }
 
         $this->classDef = new ClassDef($this->class, $flags, $this->namespace);
         $this->classDef->nativeObject = NativeClassAttributeLowering::isNative($class);

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -3354,6 +3354,21 @@ CODE;
                                 }
                                 continue;
                             }
+                            // A trait property keeps its own declaration: the
+                            // consuming class's `readonly` modifier does not
+                            // upgrade it, so Zend refuses to compose a
+                            // non-readonly (or static, which can never be
+                            // readonly) trait property into a readonly class.
+                            // Zend names the directly used trait, even when
+                            // the property originated in a nested trait.
+                            if (($classDef->flags & Modifiers::READONLY)
+                                && !($traitStmt->flags & Modifiers::READONLY)
+                            ) {
+                                $this->fatalError(
+                                    $traitStmt,
+                                    "Readonly class `{$compositionOwner}` cannot use trait with a non-readonly property `{$traitFullName}::\${$prop->name->toString()}`",
+                                );
+                            }
                             $traitProperties[$propName] = [$traitStmt, $prop];
                         }
                     }
@@ -4073,15 +4088,26 @@ CODE;
                 // Readonly-ness is part of the inheritance contract in both
                 // directions (Zend: a readonly class seals its property
                 // semantics for the whole hierarchy).
-                $childReadonly = (bool) ($this->classDef->flags & Modifiers::READONLY);
-                $parentReadonly = (bool) ($parent->flags & Modifiers::READONLY);
-                if ($childReadonly !== $parentReadonly) {
-                    $this->fatalError($class, $parentReadonly
-                        ? "Non-readonly class `{$this->class}` cannot extend readonly class `{$parentClass}`"
-                        : "Readonly class `{$this->class}` cannot extend non-readonly class `{$parentClass}`");
-                }
+                $this->assertReadonlyInheritanceContract(
+                    $class,
+                    $parentClass,
+                    (bool) ($parent->flags & Modifiers::READONLY),
+                );
             } else {
                 $this->fatalError($class, "Class `{$this->class}` inherits from a non-existent class `{$parentClass}`");
+            }
+        } elseif ($this->classDef->extends and $this->classDef->inheritedFromInternalClass and $class instanceof Node\Stmt\Class_) {
+            // Internal parents are not in the symbol table; the host runtime's
+            // reflection is authoritative for their readonly-ness (e.g.
+            // BcMath\Number is an internal readonly class, ArrayObject is not),
+            // so the contract holds in both directions here as well.
+            $parentClass = $this->getNamespacedClassName($this->parseIdentifier($class->extends));
+            if (class_exists($parentClass)) {
+                $this->assertReadonlyInheritanceContract(
+                    $class,
+                    $parentClass,
+                    (new \ReflectionClass($parentClass))->isReadOnly(),
+                );
             }
         }
 
@@ -6184,6 +6210,23 @@ CODE;
                 $classDef->properties[$prop->name] = $prop;
             }
         }
+    }
+
+    /**
+     * Zend seals readonly-ness across a class hierarchy in both directions: a
+     * readonly class cannot extend a non-readonly one and vice versa. The
+     * parent's readonly-ness comes from the symbol table for compiled classes
+     * and from host reflection for internal ones.
+     */
+    private function assertReadonlyInheritanceContract(NodeAbstract $errorNode, string $parentClass, bool $parentReadonly): void
+    {
+        $childReadonly = (bool) ($this->classDef->flags & Modifiers::READONLY);
+        if ($childReadonly === $parentReadonly) {
+            return;
+        }
+        $this->fatalError($errorNode, $parentReadonly
+            ? "Non-readonly class `{$this->class}` cannot extend readonly class `{$parentClass}`"
+            : "Readonly class `{$this->class}` cannot extend non-readonly class `{$parentClass}`");
     }
 
     private function installComposedTraitDataMembers(Node\Stmt\ClassLike $class): void

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -4070,6 +4070,16 @@ CODE;
                 if ($parent->flags & Modifiers::FINAL) {
                     $this->fatalError($class, "Class `{$this->class}` cannot extend final class `{$parentClass}`");
                 }
+                // Readonly-ness is part of the inheritance contract in both
+                // directions (Zend: a readonly class seals its property
+                // semantics for the whole hierarchy).
+                $childReadonly = (bool) ($this->classDef->flags & Modifiers::READONLY);
+                $parentReadonly = (bool) ($parent->flags & Modifiers::READONLY);
+                if ($childReadonly !== $parentReadonly) {
+                    $this->fatalError($class, $parentReadonly
+                        ? "Non-readonly class `{$this->class}` cannot extend readonly class `{$parentClass}`"
+                        : "Readonly class `{$this->class}` cannot extend non-readonly class `{$parentClass}`");
+                }
             } else {
                 $this->fatalError($class, "Class `{$this->class}` inherits from a non-existent class `{$parentClass}`");
             }

--- a/tests/compiler/class/readonly-class.phpt
+++ b/tests/compiler/class/readonly-class.phpt
@@ -4,7 +4,6 @@ Readonly Classes (PHP 8.2+)
 <?php
 
 // Test basic readonly class
-#[\AllowDynamicProperties]
 readonly class Point {
     public int $x;
     public int $y;


### PR DESCRIPTION
Readonly declaration rules were unchecked for ZendVM-backed classes (checks existed only in the Native-class branch, which rejects readonly wholesale): `public readonly int $x = 5;` (Zend: "cannot have default value"), untyped readonly ("must have type"), and static readonly all compiled, for declared and promoted properties and via `readonly class` — each rule probed for exact Zend behavior; promoted readonly params keep their legal parameter defaults.

Readonly-class inheritance was also not sealed: a non-readonly class extending a readonly one (and the reverse) compiled; both directions now fail with Zend's messages.

One pre-existing fixture (inheritance_error_prop_readonly.php) used `readonly int $x = 2`, which Zend itself rejects before the inheritance error under test; the default was dropped so the fixture still exercises the mismatch.

Part of the split of #39.
