### PR TITLE
fix(trait): preserve import context for property defaults

### DIFF
--- a/phpunit/code/trait-property-import-context/consumer.php
+++ b/phpunit/code/trait-property-import-context/consumer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace TraitPropertyImports;
+
+use TraitPropertyImports\Support\OtherLevel as ImportedLevel;
+
+trait NestedLevels
+{
+    use HasLevels;
+}
+
+class DirectConsumer
+{
+    use HasLevels;
+
+    public array $ownLevels = ['debug' => ImportedLevel::Debug];
+}
+
+class NestedConsumer
+{
+    use NestedLevels;
+}

--- a/phpunit/code/trait-property-import-context/levels.php
+++ b/phpunit/code/trait-property-import-context/levels.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace TraitPropertyImports\Support;
+
+enum Level: int
+{
+    case Debug = 100;
+}
+
+enum OtherLevel: int
+{
+    case Debug = 200;
+}

--- a/phpunit/code/trait-property-import-context/trait.php
+++ b/phpunit/code/trait-property-import-context/trait.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace TraitPropertyImports;
+
+use TraitPropertyImports\Support\Level as ImportedLevel;
+
+trait HasLevels
+{
+    public array $levels = ['debug' => ImportedLevel::Debug];
+}

--- a/phpunit/src/TraitPropertyImportContextTest.php
+++ b/phpunit/src/TraitPropertyImportContextTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use TypePhp\CompilerTest;
+
+class TraitPropertyImportContextTest extends BaseTest
+{
+    public function testPropertyDefaultsKeepTheirDeclaringFileImports(): void
+    {
+        global $translator;
+
+        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+        $translator = $compiler;
+        $directory = TYPEPHP_ROOT_PATH . '/phpunit/code/trait-property-import-context/';
+        $files = [$directory . 'levels.php', $directory . 'trait.php', $directory . 'consumer.php'];
+        $compiler->addFiles($files);
+        foreach ($files as $file) {
+            $compiler->prepareFile($file);
+        }
+        foreach ($files as $file) {
+            $compiler->convertFile($file);
+        }
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -3287,6 +3287,9 @@ CODE;
                         }
                     }
                     if ($traitStmt instanceof Node\Stmt\Property) {
+                        if ($traitStmt->getAttribute(self::TRAIT_ORIGIN_ATTRIBUTE) === null) {
+                            $traitStmt->setAttribute(self::TRAIT_ORIGIN_ATTRIBUTE, $traitFullName);
+                        }
                         foreach ($traitStmt->props as $k2 => $prop) {
                             $propName = strtolower($prop->name->toString());
                             if (isset($properties[$propName])) {
@@ -5609,7 +5612,14 @@ CODE;
             } elseif ($stmt instanceof Node\Stmt\Property) {
                 foreach ($stmt->props as $prop) {
                     if (!$this->classDef->hasProperty($prop->name->toString())) {
-                        $this->parseClassPropertyDef($stmt);
+                        $origin = $stmt->getAttribute(self::TRAIT_ORIGIN_ATTRIBUTE);
+                        if (is_string($origin)) {
+                            $this->withTraitNameContext($origin, function () use ($stmt): void {
+                                $this->parseClassPropertyDef($stmt);
+                            });
+                        } else {
+                            $this->parseClassPropertyDef($stmt);
+                        }
                         break;
                     }
                 }

--- a/tests/compiler/trait/trait-property-import-context.phpt
+++ b/tests/compiler/trait/trait-property-import-context.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Trait property defaults retain the original imports through nested composition
+--FILE--
+<?php
+namespace TraitPropertyDefaults\Support {
+    enum Level: int {
+        case Debug = 100;
+    }
+
+    enum OtherLevel: int {
+        case Debug = 200;
+    }
+}
+
+namespace TraitPropertyDefaults\Template {
+    use TraitPropertyDefaults\Support\Level;
+
+    trait HasLevels {
+        public array $levels = ['debug' => Level::Debug];
+    }
+}
+
+namespace TraitPropertyDefaults\Wrapper {
+    use TraitPropertyDefaults\Support\OtherLevel as Level;
+    use TraitPropertyDefaults\Template\HasLevels;
+
+    trait NestedLevels {
+        use HasLevels;
+    }
+}
+
+namespace TraitPropertyDefaults\Consumer {
+    use TraitPropertyDefaults\Support\OtherLevel as Level;
+    use TraitPropertyDefaults\Template\HasLevels;
+    use TraitPropertyDefaults\Wrapper\NestedLevels;
+
+    class DirectConsumer {
+        use HasLevels;
+
+        public array $ownLevels = ['debug' => Level::Debug];
+    }
+
+    class NestedConsumer {
+        use NestedLevels;
+    }
+}
+
+namespace {
+    function main(): void {
+        $direct = new TraitPropertyDefaults\Consumer\DirectConsumer();
+        $nested = new TraitPropertyDefaults\Consumer\NestedConsumer();
+        var_dump($direct->levels['debug']->value);
+        var_dump($nested->levels['debug']->value);
+        var_dump($direct->ownLevels['debug']->value);
+    }
+}
+?>
+--EXPECT--
+int(100)
+int(100)
+int(200)


### PR DESCRIPTION
I found this while trying to compile Laravel with TypePHP, in its `ParsesLogConfiguration` logging trait. The issue also reproduces without Laravel.

### Reproducer

Save as `repro.php`:

```php
<?php
namespace Repro\Support {
    enum Level: int { case Debug = 100; }
}

namespace Repro\Template {
    use Repro\Support\Level;

    trait HasLevels {
        public array $levels = ['debug' => Level::Debug];
    }
}

namespace Repro\App {
    class Logger {
        use \Repro\Template\HasLevels;
    }
}

namespace {
    function main(): void {
        echo (new \Repro\App\Logger())->levels['debug']->name, PHP_EOL;
    }
}
```

`php -r "require 'repro.php'; main();"` prints `Debug`.
`php bin/tpc.php repro.php --dry` fails with:

```text
Fatal error: Trait `Repro\Template\HasLevels` property `levels` conflicts with class `Repro\App\Logger`
```

### Fix

Composed properties were resolved with the consuming class's imports. Preserve their original trait context, including through nested traits, and use it when installing the properties. The consuming class scope and existing conflict checks are unchanged.

### Tests

- Add multi-file PHPUnit and nested-trait PHPT coverage, including conflicting consumer aliases.
- Verified PHP 8.4 output, the compiled Windows executable, and the Laravel logging scenario; 53/53 selected PHPT tests pass.
- Compared 1,540 PHPUnit tests and static-analysis diagnostics against the unmodified base: no new failures; existing baseline failures remain.
