### PR TITLE
fix(optimizer): preserve explicit round mode for Decimal

### DIFF
--- a/phpunit/code/round-with-decimal-mode.php
+++ b/phpunit/code/round-with-decimal-mode.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+function main(): void
+{
+    $decimal = std::decimal('2.5');
+
+    var_dump(round($decimal));
+    var_dump(round($decimal, 2));
+    var_dump(round($decimal, 0, PHP_ROUND_HALF_DOWN));
+}

--- a/phpunit/src/RoundModeTest.php
+++ b/phpunit/src/RoundModeTest.php
@@ -56,6 +56,16 @@ class RoundModeTest extends TestCase
         self::assertSame(2, substr_count($cpp, 'php::fn::round('));
     }
 
+    public function testDecimalWithAnExplicitModeReachesTheRuntime(): void
+    {
+        $cpp = $this->compileToCpp('round-with-decimal-mode.php');
+
+        self::assertSame(2, substr_count($cpp, 'php::Decimal::round('));
+        // Three calls wrap the results in var_dump(); the fourth is round()
+        // itself after the explicit mode disqualifies the Decimal fast path.
+        self::assertSame(4, substr_count($cpp, 'php::call('));
+    }
+
     private function compileToCpp(string $file): string
     {
         global $translator;

--- a/src/Optimizer/FuncCallOptimizer.php
+++ b/src/Optimizer/FuncCallOptimizer.php
@@ -1013,10 +1013,17 @@ trait FuncCallOptimizer
                 return false;
             }
         }
+        $args = count($e->args);
+        if ($args >= 3) {
+            // Neither optimized implementation preserves the full contract of
+            // an explicit mode. The PHPX wrapper bypasses Zend's validation,
+            // while Decimal::round() has no mode parameter at all.
+            return false;
+        }
         $type = $this->detectTypeOfExpr($e->args[0]->value);
         if ($type === Type::DECIMAL) {
             $a0 = $this->parseExpr($e->args[0]->value);
-            if (count($e->args) >= 2) {
+            if ($args >= 2) {
                 return 'php::Decimal::round(' . $a0 . ', ' . $this->parseExpr($e->args[1]->value) . ')';
             }
             return 'php::Decimal::round(' . $a0 . ')';
@@ -1028,25 +1035,7 @@ trait FuncCallOptimizer
         if (!in_array($type, [Type::INT, Type::FLOAT], true)) {
             return false;
         }
-        // PHP 8.4+ also declares $mode as int|RoundingMode. The direct PHPX
-        // wrapper takes an integer; enum objects must remain on Zend dispatch.
-        if (count($e->args) >= 3
-            && $this->detectTypeOfExpr($e->args[2]->value) !== Type::INT
-        ) {
-            return false;
-        }
         if (!$this->hasOptimizerSafeReflectedArguments($n, $e, $c)) {
-            return false;
-        }
-        $args = count($e->args);
-        if ($args >= 3) {
-            // php::fn::round() models the mode as an Int and calls
-            // _php_math_round() directly, bypassing Zend's validation of the
-            // parameter. A RoundingMode enum lowered to an int selects a
-            // different mode, and an out-of-range int aborts the process in
-            // php_round_helper instead of raising ValueError. A static int
-            // type does not prove the runtime value is one of the eight valid
-            // modes, so every explicit mode goes to the dynamic Zend path.
             return false;
         }
         if ($args >= 2) {

--- a/tests/compiler/stdlib/round-mode.phpt
+++ b/tests/compiler/stdlib/round-mode.phpt
@@ -7,6 +7,17 @@ function main()
     // A valid legacy mode still produces PHP's result.
     var_dump(round(2.5, 0, PHP_ROUND_HALF_DOWN));
     var_dump(round(3.5, 0, PHP_ROUND_HALF_ODD));
+    var_dump(round(2.5, 0, RoundingMode::HalfEven));
+
+    // TypePHP extends one- and two-argument round() to Decimal, but Decimal's
+    // native helper has no mode parameter. An explicit mode must not be
+    // silently discarded by that fast path.
+    try {
+        var_dump(round(std::decimal('2.5'), 0, PHP_ROUND_HALF_DOWN));
+        echo "decimal-type-error-not-thrown\n";
+    } catch (TypeError $e) {
+        echo "caught=decimal-mode-type-error\n";
+    }
 
     // An out-of-range integer mode must raise ValueError. The Native wrapper
     // calls _php_math_round() directly, where the same value aborts the
@@ -47,6 +58,8 @@ function main()
 --EXPECT--
 float(2)
 float(3)
+float(2)
+caught=decimal-mode-type-error
 caught=round(): Argument #3 ($mode) must be a valid rounding mode (RoundingMode::*)
 caught=round(): Argument #3 ($mode) must be a valid rounding mode (RoundingMode::*)
 caught=round(): Argument #3 ($mode) must be a valid rounding mode (RoundingMode::*)


### PR DESCRIPTION
Fixes #74

## Summary

This is a follow-up to #30. Move the explicit-mode guard in `genRound()` ahead of both optimized implementations so a three-argument Decimal call cannot silently discard its mode.

The one- and two-argument numeric and Decimal fast paths are unchanged. Named and unpacked arguments retain #30's existing early fallback.

## Invariant and failure mechanism

An optimizer may select a fast path only when it can represent every explicitly supplied argument. `php::Decimal::round()` supports TypePHP's one- and two-argument Decimal extension, but has no mode parameter.

On unpatched current `master`, the code-generation reproducer emits three `php::Decimal::round()` calls for these forms:

```php
round($decimal);
round($decimal, 2);
round($decimal, 0, PHP_ROUND_HALF_DOWN);
```

The last call is lowered as `php::Decimal::round($decimal, 0)` and loses the mode. The shared arity guard now rejects it before container/type dispatch, leaving the generic runtime call to validate the arguments.

## Relevance matrix

- Decimal, one/two arguments: native Decimal path retained.
- Decimal, explicit mode: generic path for legacy integers, `RoundingMode`, and invalid values.
- int/float, explicit mode: remains generic as established by #30.
- int/float, one/two arguments: PHPX fast path retained.
- named/unpacked calls: existing generic fallback retained.
- used/unused results share the same call-expression dispatch, so no separate lowering path is involved.
- PHPX 2.6.11 now permits the runtime PHPT to cover an internal `RoundingMode` case that #30 had to omit.

## Verification

- Unpatched current upstream: new codegen assertion fails with 3 Decimal fast-path calls instead of 2.
- `phpunit/src/RoundModeTest.php`: 5 tests, 8 assertions.
- Windows PHP 8.5.10/MSVC target PHPT: 1/1 passed.
- TypePHP self-host build completed with the patched optimizer (`/Od`).
- Fresh target artifacts compiled and executed in distinct paths at O0 (`/Od`) and O3 (`/Ox`); complete outputs were byte-identical and matched the PHPT expectation.
- Generated C++ inspected: the one/two-argument Decimal calls use `php::Decimal::round`, while the explicit-mode call uses `php::call` with all three operands.

