### PR TITLE
test(stdlib): cover RoundingMode enum at runtime

### DIFF
--- a/tests/compiler/stdlib/round-mode.phpt
+++ b/tests/compiler/stdlib/round-mode.phpt
@@ -7,6 +7,7 @@ function main()
     // A valid legacy mode still produces PHP's result.
     var_dump(round(2.5, 0, PHP_ROUND_HALF_DOWN));
     var_dump(round(3.5, 0, PHP_ROUND_HALF_ODD));
+    var_dump(round(2.5, 0, RoundingMode::HalfEven));
 
     // An out-of-range integer mode must raise ValueError. The Native wrapper
     // calls _php_math_round() directly, where the same value aborts the
@@ -47,6 +48,7 @@ function main()
 --EXPECT--
 float(2)
 float(3)
+float(2)
 caught=round(): Argument #3 ($mode) must be a valid rounding mode (RoundingMode::*)
 caught=round(): Argument #3 ($mode) must be a valid rounding mode (RoundingMode::*)
 caught=round(): Argument #3 ($mode) must be a valid rounding mode (RoundingMode::*)


### PR DESCRIPTION
Refs #29 and #30

#30 deliberately omitted native runtime coverage for `RoundingMode` because the then-pinned PHPX version could not materialize internal enum cases. TypePHP now requires PHPX 2.6.11, and current master includes the enum-case lifecycle fix, so the original interaction can be covered end to end.

This adds the smallest missing assertion to the existing `round-mode.phpt`:

```php
round(2.5, 0, RoundingMode::HalfEven); // float(2)
```

No lowering or runtime implementation changes are included.

Verification:

- Zend PHP 8.5.10: `float(2)`
- TypePHP Windows/MSVC PHPT: 1/1 passed using PHPX 2.6.11
- The existing legacy modes, invalid modes, unpacking, and one/two-argument fast-path cases remain in the same PHPT

