### PR TITLE
perf: optimize checked integer returns

### DIFF
--- a/phpunit/code/typed-scalar-arithmetic-codegen.php
+++ b/phpunit/code/typed-scalar-arithmetic-codegen.php
@@ -1,5 +1,25 @@
 <?php
 
+function addTypedInts(int $a, int $b): int
+{
+    return $a + $b;
+}
+
+function subtractTypedInts(int $a, int $b): int
+{
+    return $a - $b;
+}
+
+function multiplyTypedInts(int $a, int $b): int
+{
+    return $a * $b;
+}
+
+function addNestedTypedInts(int $a, int $b): int
+{
+    return ($a + $b) + 1;
+}
+
 function divTypedInts(int $a, int $b): float
 {
     return $a / $b;

--- a/phpunit/src/TypedScalarArithmeticCodegenTest.php
+++ b/phpunit/src/TypedScalarArithmeticCodegenTest.php
@@ -11,6 +11,16 @@ use TypePhp\CompilerTest;
  */
 final class TypedScalarArithmeticCodegenTest extends \BaseTest
 {
+    public function testTypedIntReturnUsesCheckedNativeFastPath(): void
+    {
+        $code = $this->compileFixture();
+
+        self::assertSame(1, substr_count($code, 'php::detail::intAddOverflow('));
+        self::assertSame(1, substr_count($code, 'php::detail::intSubOverflow('));
+        self::assertSame(1, substr_count($code, 'php::detail::intMulOverflow('));
+        self::assertStringContainsString('((php::Var(a)) + (b))', $code);
+    }
+
     public function testTypedIntDivisionRoutesThroughVariant(): void
     {
         $code = $this->compileFixture();

--- a/src/CompilerBase.php
+++ b/src/CompilerBase.php
@@ -2535,6 +2535,10 @@ class CompilerBase implements PropertyAccessContext
             $this->context->afterStmtLines[] = $this->getIndent() . 'return ' . $finalReturn . ';';
             return $tmpVar . ' = ' . $returnExpr . ';';
         }
+        $checkedIntReturn = $this->tryParseCheckedIntArithmeticReturn($v->expr);
+        if ($checkedIntReturn !== null) {
+            return $checkedIntReturn;
+        }
         $expr = $this->parseExprAsValue($v->expr);
         $returnType = $this->getReturnType();
 

--- a/src/Parser/BinaryOpTrait.php
+++ b/src/Parser/BinaryOpTrait.php
@@ -19,6 +19,77 @@ use PhpParser\Modifiers;
 
 trait BinaryOpTrait
 {
+    /**
+     * Emit a speculative native fast path for a strict int return.
+     *
+     * Ordinary PHP integer arithmetic remains dynamic because overflow widens
+     * the result to float. At an exact `: int` return boundary that widened
+     * value can only raise TypeError, so the common non-overflowing path may
+     * return the checked native result directly. The overflow branch still
+     * materializes a float Variant and uses the normal return-type diagnostic.
+     *
+     * Operands are deliberately restricted to reusable scalar values. More
+     * complex expressions can carry side effects or statement-scoped cleanup;
+     * evaluating those twice on the overflow branch would be incorrect.
+     */
+    protected function tryParseCheckedIntArithmeticReturn(NodeAbstract $expr): ?string
+    {
+        if ($this->nativeTypes
+            || $this->context->inClosure
+            || $this->getReturnType() !== Type::INT
+            || $this->functionDef->returnTypeCheck
+            || !($expr instanceof Expr\BinaryOp\Plus
+                || $expr instanceof Expr\BinaryOp\Minus
+                || $expr instanceof Expr\BinaryOp\Mul)
+            || !$this->isReusableCheckedIntOperand($expr->left)
+            || !$this->isReusableCheckedIntOperand($expr->right)
+            || $this->detectTypeOfExpr($expr->left) !== Type::INT
+            || $this->detectTypeOfExpr($expr->right) !== Type::INT
+            || $this->exprCanOverflowInt($expr->left)
+            || $this->exprCanOverflowInt($expr->right)
+            || $this->isExplicitNativeArithmeticExpr($expr->left)
+            || $this->isExplicitNativeArithmeticExpr($expr->right)
+        ) {
+            return null;
+        }
+
+        $left = $this->parseNumericIdentifier($expr->left);
+        $right = $this->parseNumericIdentifier($expr->right);
+        $this->checkVarMustExist($expr->left, $left);
+        $this->checkVarMustExist($expr->right, $right);
+
+        [$operator, $overflowHelper] = match (true) {
+            $expr instanceof Expr\BinaryOp\Plus => ['+', 'php::detail::intAddOverflow'],
+            $expr instanceof Expr\BinaryOp\Minus => ['-', 'php::detail::intSubOverflow'],
+            default => ['*', 'php::detail::intMulOverflow'],
+        };
+        $result = $this->addTmpVar(Type::INT);
+        $overflow = $this->genTmpVarName();
+
+        $code = 'if (UNEXPECTED(' . $overflowHelper . '(' . $left . ', ' . $right . ', &' . $result . '))) {' . PHP_EOL;
+        $this->indentLevel++;
+        $code .= $this->getIndent() . Type::VAR . ' ' . $overflow . ' = static_cast<' . Type::FLOAT . '>(' . $left . ') '
+            . $operator . ' static_cast<' . Type::FLOAT . '>(' . $right . ');' . PHP_EOL;
+        $code .= $this->genStrictScalarReturnCheck($overflow, Type::INT);
+        $this->indentLevel--;
+        $code .= $this->getIndent() . '}' . PHP_EOL;
+        $code .= $this->getIndent() . 'return ' . $result . ';';
+        return $code;
+    }
+
+    protected function isReusableCheckedIntOperand(NodeAbstract $expr): bool
+    {
+        if ($this->isVarExpr($expr)) {
+            if (!is_string($expr->name)) {
+                return false;
+            }
+            $name = $this->parseIdentifier($expr);
+            return $this->hasVar($name) && $this->getVarType($name) === Type::INT;
+        }
+
+        return $this->constantIntValue($expr) !== null;
+    }
+
     protected function parseBinaryOp(NodeAbstract $left, NodeAbstract $right, string $op): string
     {
         $this->assertExprCanBeUsedAsValue($left, 'binary operand');

--- a/tests/compiler/operator/runtime-int-overflow-return.phpt
+++ b/tests/compiler/operator/runtime-int-overflow-return.phpt
@@ -32,6 +32,10 @@ function multiplyInts(int $left, int $right): int
 
 function main(): void
 {
+    var_dump(addInts(20, 22));
+    var_dump(subtractInts(20, 22));
+    var_dump(multiplyInts(-6, 7));
+
     foreach ([
         static fn (): int => addInts(PHP_INT_MAX, 1),
         static fn (): int => subtractInts(PHP_INT_MIN, 1),
@@ -52,6 +56,9 @@ function main(): void
 }
 ?>
 --EXPECTF--
+int(42)
+int(-2)
+int(-42)
 addInts(): Return value must be of type int, float returned
 subtractInts(): Return value must be of type int, float returned
 multiplyInts(): Return value must be of type int, float returned


### PR DESCRIPTION
## Summary

- add a checked native fast path for `int + int`, `int - int`, and `int * int` at an exact `: int` return boundary
- preserve ordinary PHP overflow semantics: the uncommon overflow branch still materializes the widened `float` value and raises the existing return `TypeError`
- conservatively keep the current Variant lowering for nested/side-effecting operands, closures, composite returns, and native-types mode
- use the checked-in PHPX 2.6.12 overflow primitives; this needs no PHPX change or dependency update

## Why this is safe for TypePHP's hybrid model

Ordinary PHP integer arithmetic is not statically `int`: overflow widens the result to `float`. However, at an exact `: int` return boundary, that widened value cannot escape; it can only fail the existing strict return check.

The generated code therefore speculates on the common non-overflowing case with checked native arithmetic. On overflow it reconstructs the PHP float result and routes it through the normal TypePHP return-type diagnostic. The optimization is restricted to reusable typed-int variables and foldable integer constants so neither operand is evaluated twice.

| Dimension | Lowering |
| --- | --- |
| exact `: int`, reusable int operands, `+`/`-`/`*` | checked native fast path |
| runtime overflow | float Variant + existing `TypeError` path |
| nested/call/property/side-effecting operands | existing dynamic fallback |
| closure or union/nullable/composite return | existing dynamic fallback |
| `use native_types` / explicit native arithmetic | existing native lowering |
| other operators or operand types | unchanged |

This intentionally optimizes the static fact available at the return boundary without treating the program as wholly static.

## Performance

Fresh upstream and patched artifacts were built with the same PHP 8.5.6 ZTS / Release PHPX toolchain, GCC `-O3 -flto`. Each number is the median of 7 independent process runs; each run reports the best of 5 rounds over 10,000,000 calls.

| Benchmark | upstream/master | patched | Reduction | Speedup |
| --- | ---: | ---: | ---: | ---: |
| typed function call (`addInts`) | 17.131 ns/op | 1.145 ns/op | 93.3% | 14.96x |
| typed method call | 16.994 ns/op | 1.145 ns/op | 93.3% | 14.84x |
| function call with iteration count parsed from `argv` | 17.063 ns/op | 1.140 ns/op | 93.3% | 14.97x |

The large gain comes from removing the boxed return on the hot non-overflowing path, which lets the C++ optimizer inline and optimize through the function/method boundary. The runtime-input case guards against relying on a compile-time-known loop count.

### Zend PHP comparison

The same source was also run with the matching PHP 8.5.6 ZTS CLI, both with Opcache/JIT disabled and with CLI Opcache plus tracing JIT (`opcache.jit=tracing`, 128 MiB JIT buffer). These are medians of 7 independent processes, with the same warm-up and inner-round policy.

| Benchmark | Zend, no JIT | Zend tracing JIT | TypePHP O3+LTO | TypePHP vs no JIT | TypePHP vs JIT |
| --- | ---: | ---: | ---: | ---: | ---: |
| typed function call | 9.918 ns/op | 2.857 ns/op | 1.143 ns/op | 8.68x faster | 2.50x faster |
| typed method call | 11.194 ns/op | 3.047 ns/op | 1.147 ns/op | 9.76x faster | 2.66x faster |
| runtime-input function call | 9.906 ns/op | 2.857 ns/op | 1.141 ns/op | 8.68x faster | 2.50x faster |

This is a narrow arithmetic-call microbenchmark, not an application-wide claim. The maintained full bridge matrix still shows slower dynamic paths (notably magic calls/properties and string concatenation), which are separate optimization targets.

## Validation

- full PHPUnit: 1760 tests, 4557 assertions (pass; existing warnings/deprecations remain)
- targeted codegen PHPUnit: 4 tests, 16 assertions
- target overflow PHPT passes, including normal add/subtract/multiply and all three overflow `TypeError` cases
- self-host compiler build succeeds; `ldd` resolves the checkout PHPX and `/home/zz/.typephp` PHP; `./tpc --version` succeeds
- fresh O0 and O3+LTO AOT artifacts both match Zend output exactly; generated C++ inspected in both builds
- operator + optimization PHPT group: 83/85 pass; the two failures are unchanged on pristine upstream/master and are PHP 8.5 implicit float-to-int deprecation output (`float-bitwise-mod.phpt`, `float-narrow-nested-int-ops.phpt`)

## Relation to #79

#79 only rewrites unused for-loop post-inc/dec expressions to prefix form in `LoopControlTrait`. This PR changes checked arithmetic at exact integer return boundaries in `BinaryOpTrait`/return lowering. The files, semantic invariant, and hot paths do not overlap.
