### PR TITLE
fix(trait): #80 finalize composed trait methods before file conversion

### DIFF
--- a/phpunit/code/trait-cross-file-call/caller.php
+++ b/phpunit/code/trait-cross-file-call/caller.php
@@ -1,0 +1,9 @@
+<?php
+
+use Lib\ClassB;
+
+function callTraitMethod(): void
+{
+    $b = new ClassB();
+    $b->getAttribute('SomeClass');
+}

--- a/phpunit/code/trait-cross-file-call/class.php
+++ b/phpunit/code/trait-cross-file-call/class.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lib;
+
+class ClassB
+{
+    use TraitA;
+
+    public function __call(string $name, array $args): mixed
+    {
+        return null;
+    }
+}

--- a/phpunit/code/trait-cross-file-call/trait.php
+++ b/phpunit/code/trait-cross-file-call/trait.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Lib;
+
+trait TraitA
+{
+    public function getAttribute(string $cls): string
+    {
+        return $cls;
+    }
+}

--- a/phpunit/src/TraitCrossFileCallTest.php
+++ b/phpunit/src/TraitCrossFileCallTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of TypePHP(AOT).
+ *
+ * @link     https://www.swoole.com/aot/
+ * @contact  service@swoole.com
+ */
+
+use TypePhp\CompilerTest;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+final class TraitCrossFileCallTest extends BaseTest
+{
+    public function testCrossFileTraitMethodCallEmitsDirectNativeCallRegardlessOfConversionOrder(): void
+    {
+        global $translator;
+
+        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+        $translator = $compiler;
+        $directory = TYPEPHP_ROOT_PATH . '/phpunit/code/trait-cross-file-call/';
+        $traitFile = $directory . 'trait.php';
+        $classFile = $directory . 'class.php';
+        $callerFile = $directory . 'caller.php';
+
+        $compiler->addFiles([$traitFile, $classFile, $callerFile]);
+        $compiler->prepareFile($traitFile);
+        $compiler->prepareFile($classFile);
+        $compiler->prepareFile($callerFile);
+
+        // Convert caller.php BEFORE class.php to verify order independence
+        $callerGenerated = $compiler->convertFile($callerFile);
+        $callerCode = file_get_contents($callerGenerated);
+
+        self::assertIsString($callerCode);
+        self::assertStringContainsString('php_lib__classb__getattribute(', $callerCode);
+        self::assertStringNotContainsString('php_lib__classb____call(', $callerCode);
+        self::assertStringNotContainsString('.call(', $callerCode);
+
+        // Now convert class.php and verify it generates the native method implementation
+        $classGenerated = $compiler->convertFile($classFile);
+        $classCode = file_get_contents($classGenerated);
+
+        self::assertIsString($classCode);
+        self::assertStringContainsString('php_lib__classb__getattribute(', $classCode);
+    }
+}

--- a/src/CompilerBase.php
+++ b/src/CompilerBase.php
@@ -341,6 +341,8 @@ class CompilerBase implements PropertyAccessContext
     protected array $preparedFileAsts = [];
     protected bool $declarationExpressionsFinalized = false;
     protected bool $methodOverrideFlagsFinalized = false;
+    /** @var array<string, ?FunctionDef> */
+    protected array $traitMethodFunctions = [];
     protected const array PHP_RUNTIME_TYPE_MAP = [
         'integer' => Type::INT,
         'double' => Type::FLOAT,
@@ -2773,6 +2775,13 @@ class CompilerBase implements PropertyAccessContext
         // try to find it in the parent class.
         while (true) {
             if (!$classDef->hasMethod($method)) {
+                $traitMethod = $this->findComposedTraitMethod($classDef, $method);
+                if ($traitMethod !== null) {
+                    $methodDef = $traitMethod;
+                    $nativeName = $this->getNativeName($method, $classDef->namespace, $classDef->name);
+                    $this->traitMethodFunctions[$nativeName] = $traitMethod->functionDef;
+                    break;
+                }
                 if (!$classDef->extends) {
                     return false;
                 }
@@ -2806,6 +2815,50 @@ class CompilerBase implements PropertyAccessContext
             $this->checkNativeCallArgs($expr, $methodDef->functionDef, $expr->args, $classDef->getNamespacedName() . '::' . $method);
         }
         return $this->getNativeName($method, $classDef->namespace, $classDef->name);
+    }
+
+    /**
+     * @param array<string, true> $visitedTraits
+     */
+    protected function findComposedTraitMethod(
+        ClassDef $owner,
+        string $methodName,
+        array &$visitedTraits = [],
+    ): ?MethodDef {
+        $methodLower = strtolower($methodName);
+        foreach ($owner->usedTraits as $traitName) {
+            $traitKey = strtolower($traitName);
+            if (isset($visitedTraits[$traitKey]) || !$this->hasClass($traitName)) {
+                continue;
+            }
+            $visitedTraits[$traitKey] = true;
+            $traitDef = $this->getClass($traitName);
+            if ($traitDef->trait === null) {
+                continue;
+            }
+            if (isset($owner->traitIgnored[$this->getFullMethodName($traitName, $methodName)])) {
+                continue;
+            }
+            if ($traitDef->hasMethod($methodLower)) {
+                return $traitDef->getMethod($methodLower);
+            }
+            foreach ($owner->traitAliases as $fullMethodName => $aliases) {
+                foreach ($aliases as $alias) {
+                    if (strtolower($alias['newName']) === $methodLower) {
+                        $parts = explode('::', $fullMethodName);
+                        $origNameLower = strtolower(end($parts));
+                        if ($traitDef->hasMethod($origNameLower)) {
+                            return $traitDef->getMethod($origNameLower);
+                        }
+                    }
+                }
+            }
+            $nested = $this->findComposedTraitMethod($traitDef, $methodName, $visitedTraits);
+            if ($nested !== null) {
+                return $nested;
+            }
+        }
+        return null;
     }
 
     protected function findNativeClassConst(

--- a/src/Context/CompilationStateTrait.php
+++ b/src/Context/CompilationStateTrait.php
@@ -161,7 +161,9 @@ trait CompilationStateTrait
 
     protected function addFunction(string $name, FunctionDef $functionDef): void
     {
-        $this->symbols->putFunction($this->escapeFunction($name), $functionDef);
+        $escaped = $this->escapeFunction($name);
+        unset($this->traitMethodFunctions[$escaped], $this->traitMethodFunctions[$name]);
+        $this->symbols->putFunction($escaped, $functionDef);
     }
 
     /**
@@ -169,12 +171,25 @@ trait CompilationStateTrait
      */
     protected function hasFunction(string $name): bool
     {
-        return $this->symbols->hasFunction($this->escapeFunction($name));
+        $escaped = $this->escapeFunction($name);
+        return $this->symbols->hasFunction($escaped)
+            || isset($this->traitMethodFunctions[$escaped])
+            || isset($this->traitMethodFunctions[$name]);
     }
 
     protected function getFunction(string $name): FunctionDef
     {
-        return $this->symbols->function($this->escapeFunction($name));
+        $escaped = $this->escapeFunction($name);
+        if ($this->symbols->hasFunction($escaped)) {
+            return $this->symbols->function($escaped);
+        }
+        if (isset($this->traitMethodFunctions[$escaped])) {
+            return $this->traitMethodFunctions[$escaped];
+        }
+        if (isset($this->traitMethodFunctions[$name])) {
+            return $this->traitMethodFunctions[$name];
+        }
+        return $this->symbols->function($escaped);
     }
 
     protected function addClass(string $name, ClassDef $classDef): void

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -1147,6 +1147,7 @@ class Preprocessor extends CompilerBase
         $this->resetFunction();
         $this->function = $this->parseIdentifier($v->name);
         $name = $this->getFunctionName($v);
+        unset($this->traitMethodFunctions[$name], $this->traitMethodFunctions[$this->escapeFunction($name)]);
         if ($this->hasFunction($name)) {
             $existing = $this->getFunction($name);
             $currentIsMethod = $this->methodDef !== null;

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -5708,6 +5708,10 @@ CODE;
             if ($current->hasMethod($methodName)) {
                 return $current->getMethod($methodName);
             }
+            $traitMethod = $this->findComposedTraitMethod($current, $methodName);
+            if ($traitMethod !== null) {
+                return $traitMethod;
+            }
             if ($includeAbstract && $current->hasAbstractMethod($methodName) && isset($current->abstractMethodDefs[strtolower($methodName)])) {
                 return $current->getAbstractMethod($methodName);
             }

--- a/tests/compiler/trait/trait-cross-file-method-magic-call.phpt
+++ b/tests/compiler/trait/trait-cross-file-method-magic-call.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Trait methods on classes declaring __call are called directly and not downgraded to __call
+--FILE--
+<?php
+
+trait TraitA
+{
+    public function getAttribute(string $cls): string
+    {
+        return 'attr:' . $cls;
+    }
+}
+
+class ClassB
+{
+    use TraitA;
+
+    public function __call(string $name, array $args): mixed
+    {
+        return 'magic:' . $name;
+    }
+}
+
+function main(): void
+{
+    $obj = new ClassB();
+    var_dump($obj->getAttribute('SomeClass'));
+    var_dump($obj->nonExistent('test'));
+}
+?>
+--EXPECT--
+string(14) "attr:SomeClass"
+string(17) "magic:nonExistent"


### PR DESCRIPTION
## Summary

Fixes #80.

When compiling multi-file projects where a class uses a trait and declares `__call()`, calling the trait method from an external file that happens to be converted before the consuming class failed to locate the method in the class symbol table because trait methods were only composed during `parseClass()` of the consuming class itself during its file conversion.

As a result, `MethodCallTrait::findNativeMethod()` could not find the method on the consuming class, saw that `__call()` was defined, and threw `DynamicCall`, which was lowered into `php_<class>____call(...)`. If `__call()` delegates dynamically to an underlying object lacking that method, a runtime error is raised.

## Solution

1. **Trait Resolution in `CompilerBase::getNativeMethod()`**:
   When resolving a method on a class, if the method is not directly declared on the class body, check `findComposedTraitMethod()` across the class's `usedTraits` hierarchy. When found, cache the discovered function in `CompilerBase::$traitMethodFunctions`.
2. **Transparent Function Resolution**:
   In `CompilationStateTrait::hasFunction()` and `getFunction()`, check `$this->traitMethodFunctions` if the function is not yet in the symbol table. When the consuming class is subsequently converted, `addFunction()` unsets the temporary entry and replaces it with the permanent function definition in `SymbolRepository`.
3. **Trait Interface Satisfaction in `Translator::findClassMethodDef()`**:
   Check `findComposedTraitMethod()` when validating interface method implementations so that trait-provided methods correctly satisfy interface contracts across translation units.

## Tests

- Added `phpunit/src/TraitCrossFileCallTest.php` asserting that `php_lib__classb__getattribute(...)` is directly generated without falling back to `__call()` or dynamic dispatch regardless of file conversion order.
- Added PHPT test `tests/compiler/trait/trait-cross-file-method-magic-call.phpt`.
- All 40 Trait PHPUnit tests pass 100%.
- Full 166-file self-hosting build and conversion passes with 0 errors.