### PR TITLE
fix(optimizer): fold function aliases using resolved names

### DIFF
--- a/src/Optimizer/FuncCallOptimizer.php
+++ b/src/Optimizer/FuncCallOptimizer.php
@@ -324,7 +324,7 @@ trait FuncCallOptimizer
         }
 
         if (isset($config['constFold'])) {
-            $folded = $this->tryConstFold($config['constFold'], $config['constFoldExtra'] ?? null, $expr);
+            $folded = $this->tryConstFold($name, $config['constFold'], $config['constFoldExtra'] ?? null, $expr);
             if ($folded !== false) {
                 return $folded;
             }
@@ -715,13 +715,13 @@ trait FuncCallOptimizer
     // Constant folding
     // =========================================================================
 
-    protected function tryConstFold(int $rule, mixed $extra, Node\Expr\FuncCall $expr): string|false
+    protected function tryConstFold(string $name, int $rule, mixed $extra, Node\Expr\FuncCall $expr): string|false
     {
         return match ($rule) {
             self::FOLD_STRING_LEN => $this->doFoldStringLen($expr),
-            self::FOLD_STRING_CASE => $this->doFoldStringCase($expr),
-            self::FOLD_CMP2 => $this->doFoldCmp2($expr),
-            self::FOLD_CMP3 => $this->doFoldCmp3($expr),
+            self::FOLD_STRING_CASE => $this->doFoldStringCase($name, $expr),
+            self::FOLD_CMP2 => $this->doFoldCmp2($name, $expr),
+            self::FOLD_CMP3 => $this->doFoldCmp3($name, $expr),
             self::FOLD_COUNT_LITERAL => $this->doFoldCountLiteral($expr),
             self::FOLD_KNOWN_CLASS => $this->doFoldKnownClass($expr),
             self::FOLD_KNOWN_CONSTANT => $this->doFoldKnownConstant($expr),
@@ -738,32 +738,30 @@ trait FuncCallOptimizer
             : false;
     }
 
-    protected function doFoldStringCase(Node\Expr\FuncCall $expr): string|false
+    protected function doFoldStringCase(string $name, Node\Expr\FuncCall $expr): string|false
     {
         $arg = $expr->args[0]->value;
         if (!$this->isScalarString($arg)) {
             return false;
         }
-        $func = $expr->name instanceof Node\Name ? $expr->name->toLowerString() : '';
-        $val = $func === 'strtoupper' ? strtoupper($arg->value) : strtolower($arg->value);
+        $val = $name === 'strtoupper' ? strtoupper($arg->value) : strtolower($arg->value);
         return $this->getLiteralString($val);
     }
 
-    protected function doFoldCmp2(Node\Expr\FuncCall $expr): string|false
+    protected function doFoldCmp2(string $name, Node\Expr\FuncCall $expr): string|false
     {
         $a0 = $expr->args[0]->value;
         $a1 = $expr->args[1]->value;
         if (!$this->isScalarString($a0) || !$this->isScalarString($a1)) {
             return false;
         }
-        $func = $expr->name instanceof Node\Name ? $expr->name->toLowerString() : '';
-        $result = $func === 'strcasecmp'
+        $result = $name === 'strcasecmp'
             ? strcasecmp($a0->value, $a1->value)
             : strcmp($a0->value, $a1->value);
         return $result . $this->getPlatform()->getIntegerLiteralSuffix();
     }
 
-    protected function doFoldCmp3(Node\Expr\FuncCall $expr): string|false
+    protected function doFoldCmp3(string $name, Node\Expr\FuncCall $expr): string|false
     {
         $a0 = $expr->args[0]->value;
         $a1 = $expr->args[1]->value;
@@ -771,8 +769,7 @@ trait FuncCallOptimizer
         if (!$this->isScalarString($a0) || !$this->isScalarString($a1) || !$this->isScalarInt($a2)) {
             return false;
         }
-        $func = $expr->name instanceof Node\Name ? $expr->name->toLowerString() : '';
-        $result = $func === 'strncasecmp'
+        $result = $name === 'strncasecmp'
             ? strncasecmp($a0->value, $a1->value, (int) $a2->value)
             : strncmp($a0->value, $a1->value, (int) $a2->value);
         return $result . $this->getPlatform()->getIntegerLiteralSuffix();

--- a/tests/compiler/namespace/use-function-alias-constant-folding.phpt
+++ b/tests/compiler/namespace/use-function-alias-constant-folding.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Constant folding uses resolved function names for imported aliases
+--FILE--
+<?php
+namespace FunctionAliasFolding {
+    use function strtoupper as upper;
+    use function strtolower as strtoupper;
+    use function strcasecmp as compare;
+    use function strcmp as strcasecmp;
+    use function strncasecmp as compare_prefix;
+    use function strncmp as strncasecmp;
+
+    function run(): void
+    {
+        var_dump(upper('MiXeD'));
+        var_dump(strtoupper('MiXeD'));
+        var_dump(compare('A', 'a'));
+        var_dump(strcasecmp('A', 'a') !== 0);
+        var_dump(compare_prefix('A', 'a', 1));
+        var_dump(strncasecmp('A', 'a', 1) !== 0);
+    }
+}
+
+namespace {
+    function main(): void
+    {
+        FunctionAliasFolding\run();
+    }
+}
+?>
+--EXPECT--
+string(5) "MIXED"
+string(5) "mixed"
+int(0)
+bool(true)
+int(0)
+bool(true)


### PR DESCRIPTION
Imported aliases could make constant folding execute the wrong string function. For example, `use function strtoupper as upper; upper('MiXeD')` compiled to `"mixed"` instead of `"MIXED"`. The same issue affected case-sensitive and case-insensitive string comparisons.

Pass the resolved function name through constant-fold dispatch instead of reading the original AST alias. Add a PHPT covering both directions of case conversion and two-/three-argument comparison, including aliases that shadow another built-in name.

Validation on Linux ARM64 with PHP 8.5.10:
- New PHPT fails before the fix and passes afterward; its six expected results also match plain PHP.
- New PHPT and existing `use-function-alias.phpt`: 2 passed with native AOT compilation.
- `FuncCallOptimizerTest` and `FuncCallOptimizerUnpackTest`: 2 tests, 23 assertions passed.
- `git diff --check` passed.
