### PR TITLE
fix(compiler): evaluate trailing empty switch cases

### DIFF
--- a/src/Parser/SwitchTrait.php
+++ b/src/Parser/SwitchTrait.php
@@ -124,6 +124,13 @@ trait SwitchTrait
             $caseConds = [];
             $hasDefault = false;
         }
+        if (!empty($caseConds) || $hasDefault) {
+            $target = count($caseGroups);
+            if ($hasDefault) {
+                $defaultTarget = $target;
+            }
+            $caseGroups[] = [$caseConds, $hasDefault, []];
+        }
 
         foreach ($caseGroups as $groupIndex => [$conds]) {
             if (!empty($conds)) {
@@ -171,14 +178,6 @@ trait SwitchTrait
             $code .= $this->parseStmts($stmts);
             $this->indentLevel--;
             $code .= $this->getIndent() . '}' . PHP_EOL;
-        }
-        if (!empty($caseConds) || $hasDefault) {
-            // PHP allows a trailing label without statements; it has no code to execute.
-            if ($hasDefault && $defaultTarget === null) {
-                $code .= $this->getIndent() . 'if (!' . $switchMatched . ') {' . PHP_EOL;
-                $code .= $this->getIndent() . $switchTarget . ' = -1;' . PHP_EOL;
-                $code .= $this->getIndent() . '}' . PHP_EOL;
-            }
         }
         $this->indentLevel--;
         $code .= $this->getIndent() . '} while (0);';

--- a/tests/compiler/switch/trailing-empty-case.phpt
+++ b/tests/compiler/switch/trailing-empty-case.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Switch evaluates and matches a trailing empty case
+--FILE--
+<?php
+function mark(string $value): string
+{
+    echo "evaluated:$value\n";
+    return $value;
+}
+
+function main(): void
+{
+    switch ('subject') {
+        default:
+            echo "default\n";
+            break;
+        case mark('other'):
+    }
+
+    switch ('subject') {
+        default:
+            echo "default\n";
+            break;
+        case mark('subject'):
+    }
+
+    switch ('subject') {
+        default:
+            echo "unexpected-default\n";
+            break;
+        case mark('first-miss'):
+        case mark('subject'):
+    }
+
+    switch ('subject') {
+        case mark('default-miss'):
+            echo "unexpected-case\n";
+            break;
+        default:
+    }
+}
+?>
+--EXPECT--
+evaluated:other
+default
+evaluated:subject
+evaluated:first-miss
+evaluated:subject
+evaluated:default-miss


### PR DESCRIPTION
A trailing empty switch case was discarded during AOT lowering. Its condition was never evaluated, and even a matching trailing case could incorrectly execute an earlier default branch.

Keep trailing case/default labels as an empty case group so the existing ordered comparison logic evaluates them and suppresses the default when they match. Add a PHPT covering both observable condition side effects and default suppression.

Validation on Linux ARM64 with PHP 8.5.10:
- New regression fails before the fix and passes afterward; its expected output matches plain PHP.
- `tests/compiler/switch`: 7/7 passed with native AOT compilation.
- Applied together with the separate switch-type-comparison fix: all three new PHPT regressions passed.
- `git diff --check` passed.
