### PR TITLE
fix(compiler): avoid native object filename collisions

### DIFF
--- a/phpunit/src/CompilerBaseApiTest.php
+++ b/phpunit/src/CompilerBaseApiTest.php
@@ -286,7 +286,7 @@ PHP);
     public function testMiscObjectCacheIsInvalidatedWhenCompileOptionsChange(): void
     {
         $source = $this->testDir . '/typephp_runtime.cc';
-        $object = $this->testDir . '/typephp_runtime.o';
+        $object = $this->compiler->getObjectFile($source);
         file_put_contents($source, "int typephp_runtime_test = 1;\n");
         file_put_contents($object, 'object');
         touch($source, time() - 10);

--- a/phpunit/src/PreprocessorTest.php
+++ b/phpunit/src/PreprocessorTest.php
@@ -187,8 +187,7 @@ class PreprocessorTest extends TestCase
         $cppFile = $this->compiler->getBuildDir() . '/include/test.cc';
         $result = $this->compiler->getObjectFile($cppFile);
 
-        $this->assertStringEndsWith('.o', $result);
-        $this->assertStringContainsString('test', $result);
+        $this->assertSame($this->compiler->getBuildDir() . '/include/test.o', $result);
     }
 
     public function testGetObjectFileDifferentObjectExtension(): void
@@ -196,7 +195,18 @@ class PreprocessorTest extends TestCase
         // On Linux the object extension is .o
         $path = '/some/path/file.cc';
         $result = $this->compiler->getObjectFile($path);
-        $this->assertStringEndsWith('file.o', $result);
+        $this->assertStringEndsWith('file.cc.o', $result);
+    }
+
+    public function testGetObjectFileKeepsNativeSourceExtensionsDistinct(): void
+    {
+        $cObject = $this->compiler->getObjectFile('/some/path/foo.c');
+        $cppObject = $this->compiler->getObjectFile('/some/path/foo.cpp');
+        $ccObject = $this->compiler->getObjectFile('/some/path/foo.cc');
+
+        $this->assertSame('/some/path/foo.c.o', $cObject);
+        $this->assertSame('/some/path/foo.cpp.o', $cppObject);
+        $this->assertSame('/some/path/foo.cc.o', $ccObject);
     }
 
     // ========================================================================

--- a/src/Preprocessor.php
+++ b/src/Preprocessor.php
@@ -340,7 +340,25 @@ class Preprocessor extends CompilerBase
             return $objectDir . $separator . $info['filename'] . $ext;
         }
 
-        return $info['dirname'] . $this->getPlatform()->getPathSeparator() . $info['filename'] . $ext;
+        $filename = $info['filename'];
+        if (!$this->isGeneratedCppFile($cppFile)) {
+            // Native sources keep their original paths, so their extensions
+            // distinguish files such as foo.c and foo.cpp in one directory.
+            $filename .= '.' . $info['extension'];
+        }
+
+        return $info['dirname'] . $this->getPlatform()->getPathSeparator() . $filename . $ext;
+    }
+
+    private function isGeneratedCppFile(string $file): bool
+    {
+        if (pathinfo($file, PATHINFO_EXTENSION) !== 'cc') {
+            return false;
+        }
+
+        $normalizedFile = str_replace('\\', '/', $file);
+        $normalizedBuildDir = rtrim(str_replace('\\', '/', $this->buildDir), '/') . '/';
+        return str_starts_with($normalizedFile, $normalizedBuildDir);
     }
 
     protected function isProjectRuntimeEntryFile(string $file): bool


### PR DESCRIPTION
Native sources with the same basename, such as `foo.c` and `foo.cpp`, compiled to the same `foo.o`. The second compilation overwrote the first object, and linking the repeated object path failed with duplicate symbol definitions even in a sequential build.

Preserve source extensions in native object filenames (`foo.c.o`, `foo.cpp.o`, `foo.cc.o`). Keep object names for generated TypePHP `.cc` files inside the build directory and PHPX misc cache files unchanged. Add a regression for distinct native object paths and update the cache-test fixture to use the compiler's object-path mapping.

Validation on Linux ARM64 with PHP 8.5.10:
- New object-name regression fails before the fix and passes afterward.
- `PreprocessorTest` and the misc-cache tests in `CompilerBaseApiTest`: 37 tests / 98 assertions passed. PHP 8.5 reports existing `ReflectionProperty::setAccessible()` / `ReflectionMethod::setAccessible()` deprecations in the test helpers.
- A real CLI project containing `foo.c` and `foo.cpp` builds, links, and runs successfully; `nm` confirms both native symbols are retained in separate objects.
- `git diff --check` passed.
