### PR TITLE
fix(compiler): support first-class callable of internal functions

### DIFF
--- a/phpunit/src/SsaAnalysisTest.php
+++ b/phpunit/src/SsaAnalysisTest.php
@@ -1345,6 +1345,18 @@ class SsaAnalysisTest extends TestCase
         }
     }
 
+    public function testDetectTypeOfFirstClassCallableBeforeBuiltinReturnTypeOptimizations(): void
+    {
+        foreach (['round', 'fopen'] as $function) {
+            $call = new Expr\FuncCall(
+                new Node\Name($function),
+                [new Node\VariadicPlaceholder()]
+            );
+
+            $this->assertSame(Type::OBJECT, $this->invoke('detectTypeOfExpr', $call));
+        }
+    }
+
     public function testDetectTypeOfConcatExpressions(): void
     {
         $concat = new Expr\BinaryOp\Concat(new Scalar\LNumber(1), new Scalar\String_(''));

--- a/src/CompilerBase.php
+++ b/src/CompilerBase.php
@@ -3142,8 +3142,13 @@ class CompilerBase implements PropertyAccessContext
                 if ($this->isNameExpr($expr->name)) {
                     $name = $this->parseIdentifier($expr->name);
                     $globalName = ltrim($name, '\\');
-                    // Math function optimization: propagate Big* return types
-                    if (in_array($name, ['abs', 'pow', 'sqrt', 'floor', 'ceil', 'round'], true) && !empty($expr->args)) {
+                    // Math function optimization: propagate Big* return types.
+                    // Skip first-class callables like `round(...)`: their single
+                    // VariadicPlaceholder arg has no ->value, and they resolve to
+                    // a Closure (Type::OBJECT) further below.
+                    if (in_array($name, ['abs', 'pow', 'sqrt', 'floor', 'ceil', 'round'], true)
+                        && !empty($expr->args)
+                        && !$expr->isFirstClassCallable()) {
                         $argType = $this->detectTypeOfExpr($expr->args[0]->value);
                         if (
                             $argType === Type::BIGINT
@@ -3456,6 +3461,12 @@ class CompilerBase implements PropertyAccessContext
             $this->validateInternalNamedCallArgs($ref, $expr->args);
         }
         if ($this->hasUnpackCallArg($expr->args)) {
+            return;
+        }
+        // `foo(...)` is PHP 8.1 first-class callable syntax: it creates a
+        // Closure instead of calling foo, so its single VariadicPlaceholder
+        // must not be counted/validated against foo's real signature.
+        if ($expr->isFirstClassCallable()) {
             return;
         }
         $actualArgCount = count($expr->args);

--- a/src/CompilerBase.php
+++ b/src/CompilerBase.php
@@ -3139,16 +3139,15 @@ class CompilerBase implements PropertyAccessContext
                 }
                 break;
             case 'Expr_FuncCall':
+                if ($expr->isFirstClassCallable()) {
+                    return Type::OBJECT;
+                }
                 if ($this->isNameExpr($expr->name)) {
                     $name = $this->parseIdentifier($expr->name);
                     $globalName = ltrim($name, '\\');
-                    // Math function optimization: propagate Big* return types.
-                    // Skip first-class callables like `round(...)`: their single
-                    // VariadicPlaceholder arg has no ->value, and they resolve to
-                    // a Closure (Type::OBJECT) further below.
+                    // Math function optimization: propagate Big* return types
                     if (in_array($name, ['abs', 'pow', 'sqrt', 'floor', 'ceil', 'round'], true)
-                        && !empty($expr->args)
-                        && !$expr->isFirstClassCallable()) {
+                        && !empty($expr->args)) {
                         $argType = $this->detectTypeOfExpr($expr->args[0]->value);
                         if (
                             $argType === Type::BIGINT
@@ -3171,9 +3170,6 @@ class CompilerBase implements PropertyAccessContext
                     }
                     if (in_array($name, self::STREAM_FUNCTIONS)) {
                         return Type::STREAM;
-                    }
-                    if (count($expr->args) === 1 and $this->isPlaceholderExpr($expr->args[0])) {
-                        return Type::OBJECT;
                     }
                     if ($this->hasFunction($name)) {
                         return $this->getFunction($name)->returnType;

--- a/tests/compiler/place-holder/builtin-multi-arg-callable.phpt
+++ b/tests/compiler/place-holder/builtin-multi-arg-callable.phpt
@@ -1,0 +1,19 @@
+--TEST--
+First-class callable of builtins requiring multiple arguments
+--FILE--
+<?php
+function main(): void {
+    // str_repeat() and array_slice() are internal functions with 2 required
+    // parameters. `foo(...)` builds a Closure; its single VariadicPlaceholder
+    // must not be counted as one real argument and rejected by the internal
+    // function argument-count check.
+    $repeat = str_repeat(...);
+    echo $repeat('ab', 3), "\n";
+
+    $slice = array_slice(...);
+    echo implode(',', $slice([1, 2, 3, 4, 5], 1, 2)), "\n";
+}
+?>
+--EXPECT--
+ababab
+2,3

--- a/tests/compiler/place-holder/math-function-callable.phpt
+++ b/tests/compiler/place-holder/math-function-callable.phpt
@@ -1,0 +1,16 @@
+--TEST--
+First-class callable of a math function (round)
+--FILE--
+<?php
+function main(): void {
+    // round() is in the math-function return-type optimization list. For the
+    // first-class callable `round(...)`, args[0] is a VariadicPlaceholder with
+    // no ->value, so the optimization must be skipped and the expression must
+    // resolve to a Closure instead of crashing.
+    $values = [1.4, 2.6, 3.5];
+    $rounded = array_map(round(...), $values);
+    echo implode(',', $rounded), "\n";
+}
+?>
+--EXPECT--
+1,3,4

--- a/tests/compiler/place-holder/stream-function-callable.phpt
+++ b/tests/compiler/place-holder/stream-function-callable.phpt
@@ -1,0 +1,14 @@
+--TEST--
+First-class callable of a stream-returning function
+--FILE--
+<?php
+function useOpener(Closure $open): void {
+    echo "callable\n";
+}
+
+function main(): void {
+    useOpener(fopen(...));
+}
+?>
+--EXPECT--
+callable


### PR DESCRIPTION
Scope: first-class callable handling for internal functions only.

This change skips internal-function argument-count validation when PHP 8.1 first-class callable syntax is used, because `foo(...)` creates a Closure rather than invoking `foo`.

It also skips mathematical-function return-type optimization for that syntax, preventing access to `VariadicPlaceholder::$value`, which is absent for the placeholder argument.

Validation: callable-only commit replayed on current master; `git range-diff` and `git diff --check` pass; `php vendor/bin/phpunit phpunit/src/AssignTest.php` passes (34 tests). Regression coverage is in `builtin-multi-arg-callable.phpt` and `math-function-callable.phpt`.