### PR TITLE
fix(compiler): allow re-assigning inferred local object to another class

### DIFF
--- a/src/Parser/AssignOpTrait.php
+++ b/src/Parser/AssignOpTrait.php
@@ -568,7 +568,7 @@ trait AssignOpTrait
                         // Parent/interface/abstract declarations are not precise enough for a concrete typed object.
                         $runtimeObjectAssignClass = $leftClass;
                     } else {
-                        $this->fatalError($left, "Cannot re-assign typed object `\${$var}` from `{$leftClass}` to `{$rightClass}`");
+                        $this->reassignInferredObjectVar($left, $var, $leftClass, $rightClass);
                     }
                 } else {
                     $this->checkVarAssignExpr($left, $this->getVarType($var), Type::OBJECT);
@@ -644,7 +644,7 @@ trait AssignOpTrait
                         } elseif ($this->isInterface($rightClass) || $this->isAbstractClass($rightClass) || $this->isObjectClassStaticallyAssignableTo($leftClass, $rightClass)) {
                             $runtimeObjectAssignClass = $leftClass;
                         } else {
-                            $this->fatalError($left, "Cannot re-assign typed object `\${$var}` from `{$leftClass}` to `{$rightClass}`");
+                            $this->reassignInferredObjectVar($left, $var, $leftClass, $rightClass);
                         }
                     }
                 }
@@ -731,6 +731,27 @@ trait AssignOpTrait
             return '';
         }
         return $var . ' = ' . $assignedExpr;
+    }
+
+    /**
+     * PHP local variables carry no type declaration; the class tracked for
+     * `$var` was inferred from an earlier assignment. Re-assigning an unrelated
+     * concrete class in a mutually exclusive branch (for example if/else) is
+     * valid PHP, so widen the inferred local to a generic dynamic object rather
+     * than rejecting it. Parameters, native objects, and explicitly declared
+     * object types keep their strict re-assignment check.
+     */
+    protected function reassignInferredObjectVar(Expr $left, string $var, string $leftClass, string $rightClass): void
+    {
+        $canWiden = !$this->hasArgument($var)
+            && !$this->isNativeObjectVar($var)
+            && isset($this->context->objects[$var])
+            && !isset($this->context->declaredObjects[$var]);
+        if (!$canWiden) {
+            $this->fatalError($left, "Cannot re-assign typed object `\${$var}` from `{$leftClass}` to `{$rightClass}`");
+        }
+        unset($this->context->objects[$var], $this->context->stableObjects[$var], $this->context->declaredObjects[$var]);
+        $this->addLocalVar($var, Type::OBJECT);
     }
 
     protected function parseAssignPropertyHook(

--- a/tests/compiler/reflection/inferred-object-reassign.phpt
+++ b/tests/compiler/reflection/inferred-object-reassign.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Re-assign an inferred local object to a different class across if/else
+--FILE--
+<?php
+function main(): void {
+    // A local variable has no type declaration: its class is inferred from the
+    // first assignment. Assigning a different concrete class in a mutually
+    // exclusive branch is valid PHP, so the inferred local must widen to a
+    // dynamic object rather than being rejected.
+    $a = 'strlen';
+    if (is_string($a)) {
+        $ref = new ReflectionFunction($a);
+    } else {
+        $ref = new ReflectionMethod($a, 'count');
+    }
+    echo get_class($ref), "\n";
+
+    $b = [ArrayObject::class, 'count'];
+    if (is_string($b)) {
+        $ref2 = new ReflectionFunction($b);
+    } else {
+        $ref2 = new ReflectionMethod($b[0], $b[1]);
+    }
+    echo get_class($ref2), "\n";
+}
+?>
+--EXPECT--
+ReflectionFunction
+ReflectionMethod


### PR DESCRIPTION
A local variable has no type declaration; its class is inferred from the first assignment. Re-assigning an unrelated concrete class in a mutually exclusive branch (e.g. ReflectionFunction in `if` and ReflectionMethod in `else`) is valid PHP, but was rejected with "Cannot re-assign typed object".

Route both re-assignment sites through reassignInferredObjectVar(), which widens an inferred local to a generic dynamic object. Parameters, native objects, and explicitly declared object types keep the strict check.