### PR TITLE
Avoid temporary Variants when binding hoisted numeric property slots

### DIFF
--- a/phpunit/src/NativePropertyTest.php
+++ b/phpunit/src/NativePropertyTest.php
@@ -59,7 +59,7 @@ class NativePropertyTest extends \BaseTest
         }
 
         $code = file_get_contents($outputFile);
-        $this->assertStringContainsString('php::Int &_object_prop_this___value = Z_LVAL_P(this_.attr(', $code);
+        $this->assertStringContainsString('php::Int &_object_prop_this___value = Z_LVAL_P(php::unwrap_zval(OBJ_PROP(this_.checkedObject("Attempt to read property"), ', $code);
         $this->assertStringContainsString('php::Int &_object_prop_box__value = Z_LVAL_P(box.attr(', $code);
         $this->assertStringContainsString('_object_prop_this___value += (2L);', $code);
         $this->assertStringContainsString('_object_prop_box__value += (2L);', $code);
@@ -92,7 +92,7 @@ class NativePropertyTest extends \BaseTest
         }
 
         $code = file_get_contents($outputFile);
-        $this->assertStringContainsString('php::Int &_object_prop_this___flags = Z_LVAL_P(this_.attr(', $code);
+        $this->assertStringContainsString('php::Int &_object_prop_this___flags = Z_LVAL_P(php::unwrap_zval(OBJ_PROP(this_.checkedObject("Attempt to read property"), ', $code);
         // A TypePHP class constant is available during conversion and is
         // folded before the native property operation is emitted.
         $this->assertStringContainsString('_object_prop_this___flags &= (~php::toInt(1L));', $code);
@@ -125,7 +125,7 @@ class NativePropertyTest extends \BaseTest
         }
 
         $code = file_get_contents($outputFile);
-        $this->assertStringContainsString('php::Int &_object_prop_this___value = Z_LVAL_P(this_.attr(', $code);
+        $this->assertStringContainsString('php::Int &_object_prop_this___value = Z_LVAL_P(php::unwrap_zval(OBJ_PROP(this_.checkedObject("Attempt to read property"), ', $code);
         $this->assertStringContainsString('_object_prop_this___value = php::toIntExact(dynamicValue, "NativePropertyThisWriteConversionBox::$value");', $code);
     }
 

--- a/src/CompilerBase.php
+++ b/src/CompilerBase.php
@@ -5341,7 +5341,7 @@ class CompilerBase implements PropertyAccessContext
                 $code .= $this->getIndent() . Type::VAR . ' ' . $name . ' = ' . $info['getter'] . ';' . PHP_EOL;
             } else {
                 $zvalMacro = ($info['type'] === Type::FLOAT) ? 'Z_DVAL_P' : 'Z_LVAL_P';
-                $code .= $this->getIndent() . $info['type'] . ' &' . $name . ' = ' . $zvalMacro . '(' . $info['getter'] . '.unwrap_ptr());' . PHP_EOL;
+                $code .= $this->getIndent() . $info['type'] . ' &' . $name . ' = ' . $zvalMacro . '(' . $info['getter'] . ');' . PHP_EOL;
             }
         }
         foreach ($this->context->staticPropRefs as $info) {

--- a/src/Parser/PropertyAccessTrait.php
+++ b/src/Parser/PropertyAccessTrait.php
@@ -1382,6 +1382,11 @@ trait PropertyAccessTrait
             if (!$this->canHoistObjectProp($objectVar, $propName, $def)) {
                 return null;
             }
+            if (in_array($def->type, [Type::INT, Type::FLOAT], true)) {
+                // Bind the native reference to the fixed slot without a temporary Variant.
+                $getter = 'php::unwrap_zval(OBJ_PROP(' . $objectVar
+                    . '.checkedObject("Attempt to read property"), ' . $propertyId . '))';
+            }
             $this->registerHoistedObjectPropVar($propVar, $def->type, $getter);
             $this->setNativePropertyVar($expr, $propVar);
             $this->setNativePropertyValueSource($expr, self::NATIVE_PROPERTY_VALUE_VAR);

--- a/tests/compiler/optimizations/objprop-hoist-this-inherited-reference.phpt
+++ b/tests/compiler/optimizations/objprop-hoist-this-inherited-reference.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Hoisted this numeric slots preserve inherited properties and existing references
+--FILE--
+<?php
+class SlotBase {
+    public int $count = 2;
+    public float $weight = 1.5;
+}
+class SlotChild extends SlotBase {
+    public function update(): void {
+        $this->count += 3;
+        $this->weight += 0.5;
+    }
+}
+function main(): void {
+    $object = new SlotChild();
+    $count =& $object->count;
+    $weight =& $object->weight;
+    $object->update();
+    var_dump($count, $weight);
+    $count = 10;
+    $weight = 3.5;
+    $object->update();
+    var_dump($count, $weight);
+}
+?>
+--EXPECT--
+int(5)
+float(2)
+int(13)
+float(4)


### PR DESCRIPTION
When binding an already-hoistable `$this` int or float property to a native
reference, generated code constructs a temporary `Variant` through `attr()`
and immediately calls `unwrap_ptr()`. Bind directly to the checked object slot
and dereference existing property references instead. Existing hoisting safety
checks, property offsets and write conversions are preserved.

In an isolated benchmark repeatedly updating an int and float property,
300 million calls took a median 1.7556 s before and 1.2549 s after across nine
alternating pairs (28.5% less elapsed time; all nine pairs faster), using
PHP 8.5.10 ZTS on Linux ARM64 with GCC -O2.

Validation: 22 native-property code-generation tests and four targeted PHPTs
pass, including inherited properties with existing external references,
object escape, unset and float access. Performance on other platforms and
NTS has not been measured.

<details>
<summary>Standalone benchmark source</summary>

```php
<?php
class Counter {
    public int $value = 1;
    public float $weight = 0.5;
    public function step(int $delta): int {
        $this->value += $delta;
        $this->weight += 0.5;
        return $this->value;
    }
}
function main(int $argc, array $argv): void {
    $n = $argc > 1 ? (int) $argv[1] : 1000000;
    $counter = new Counter();
    $sum = 0;
    for ($i = 0; $i < $n; ++$i) {
        $sum += $counter->step($i % 3);
    }
    echo $sum, ':', $counter->weight, "\n";
}
```

Build as a binary with `optimize: 2`. Run each binary with argument `300000000`, after a warmup, alternating baseline/candidate order for nine rounds. Verify identical output (`45000000250000000:150000000.5`), zero exit status and empty stderr. Timings include process startup.
</details>
