### PR TITLE
Mark generated literal and cache slot accessors noexcept

### DIFF
--- a/phpunit/src/CallCacheCodegenTest.php
+++ b/phpunit/src/CallCacheCodegenTest.php
@@ -43,6 +43,44 @@ final class CallCacheCodegenTest extends BaseTest
         self::assertStringContainsString('typephp_get_method_call_cache(MethodCallCacheId cache_id)', $extension);
     }
 
+    public function testSlotAccessorsDeclareNoexceptWithoutChangingResolvingLookups(): void
+    {
+        global $translator;
+        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+        $translator = $compiler;
+        $compiler->setBuildMode(CompilerBase::BUILD_MODE_EXT);
+        $compiler->setTargetName('noexcept_cache_accessors');
+        $source = TYPEPHP_ROOT_PATH . '/phpunit/code/call-cache-sites.php';
+        $compiler->addFiles([$source]);
+        $compiler->prepareFile($source);
+        $compiler->convertFile($source);
+        $headerFile = tempnam(sys_get_temp_dir(), 'typephp-noexcept-');
+        try {
+            $compiler->genDataDeclarations($headerFile);
+            $header = file_get_contents($headerFile);
+            $extension = file_get_contents($compiler->genExtension());
+            foreach ([
+                'get_property_cache(PropertyCacheId cache_id)',
+                'typephp_get_method_call_cache(MethodCallCacheId cache_id)',
+                'typephp_get_function_call_cache(FunctionCallCacheId cache_id)',
+            ] as $signature) {
+                self::assertStringContainsString($signature . ' noexcept;', $header);
+                self::assertStringContainsString($signature . ' noexcept {', $extension);
+            }
+            // Resolving lookups may throw and must retain that contract.
+            self::assertStringContainsString(
+                'get_persistent_func(PersistentFuncId func_id, const php::Str &func_name);',
+                $header,
+            );
+            self::assertStringContainsString(
+                'get_persistent_func(PersistentFuncId func_id, const php::Str &func_name) {',
+                $extension,
+            );
+        } finally {
+            unlink($headerFile);
+        }
+    }
+
     public function testCallArgumentLimitRejectsBrokenUnboundedLowering(): void
     {
         $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);

--- a/phpunit/src/CompilerBaseApiTest.php
+++ b/phpunit/src/CompilerBaseApiTest.php
@@ -1499,7 +1499,7 @@ YAML);
         $this->assertStringContainsString('extern php::Var _const_var_EXPORTED_ABI_STRING;', $dataHeader);
         $this->assertStringContainsString('extern php::Var _const_var_EXPORTED_ABI_ARRAY;', $dataHeader);
         $this->assertStringContainsString(
-            'ZEND_ATTRIBUTE_CONST php::Str &get_str(uint32_t index);',
+            'ZEND_ATTRIBUTE_CONST php::Str &get_str(uint32_t index) noexcept;',
             $dataHeader,
         );
         $this->assertStringNotContainsString('_literal_strings', $dataHeader);
@@ -1510,6 +1510,7 @@ YAML);
         $extension = file_get_contents($extensionFile);
         $this->assertStringContainsString('php::Str php_exported_defaults_arg_0_default_value() {', $extension);
         $this->assertStringContainsString('static php::Str _literal_strings[]', $extension);
+        $this->assertStringContainsString('php::Str &get_str(uint32_t index) noexcept {', $extension);
         $this->assertStringContainsString('return get_str(', $extension);
         $this->assertStringContainsString('php::Array php_exported_variadic_arg_0_default_value() {', $extension);
     }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -975,7 +975,7 @@ class Translator extends Preprocessor
 
         if ($this->literalStrings) {
             $lines[] = 'ZEND_ATTRIBUTE_CONST ' . Type::STR . ' &'
-                . self::LITERAL_STRING_GETTER . '(uint32_t index);' . PHP_EOL;
+                . self::LITERAL_STRING_GETTER . '(uint32_t index) noexcept;' . PHP_EOL;
         }
 
         foreach ($this->constants as $name => $constant) {
@@ -1003,9 +1003,9 @@ class Translator extends Preprocessor
         $lines[] = 'zend_function *get_persistent_func(PersistentFuncId func_id, const php::Str &func_name);';
         $lines[] = 'zend_function *get_persistent_method(PersistentFuncId func_id, const php::Str &method_name, PersistentClassId class_id, const php::Str &class_name);';
         $lines[] = 'uint32_t get_persistent_prop(PersistentPropertyId prop_id, const php::Str &prop_name, const php::Str &class_name);' . PHP_EOL;
-        $lines[] = 'php::PropertyCacheSlot &get_property_cache(PropertyCacheId cache_id);' . PHP_EOL;
-        $lines[] = 'php::MethodCallCacheSlot &typephp_get_method_call_cache(MethodCallCacheId cache_id);' . PHP_EOL;
-        $lines[] = 'php::FunctionCallCacheSlot &typephp_get_function_call_cache(FunctionCallCacheId cache_id);' . PHP_EOL;
+        $lines[] = 'php::PropertyCacheSlot &get_property_cache(PropertyCacheId cache_id) noexcept;' . PHP_EOL;
+        $lines[] = 'php::MethodCallCacheSlot &typephp_get_method_call_cache(MethodCallCacheId cache_id) noexcept;' . PHP_EOL;
+        $lines[] = 'php::FunctionCallCacheSlot &typephp_get_function_call_cache(FunctionCallCacheId cache_id) noexcept;' . PHP_EOL;
 
         foreach ($this->getClassLikesWithConstants() as $classDef) {
             foreach ($classDef->constants as $constant) {
@@ -1275,15 +1275,15 @@ uint32_t get_persistent_prop(PersistentPropertyId prop_id, const php::Str &prop_
     return value - 1024;
 }
 
-php::PropertyCacheSlot &get_property_cache(PropertyCacheId cache_id) {
+php::PropertyCacheSlot &get_property_cache(PropertyCacheId cache_id) noexcept {
     return php_request_cache->property_cache_map[static_cast<uint32_t>(cache_id)];
 }
 
-php::MethodCallCacheSlot &typephp_get_method_call_cache(MethodCallCacheId cache_id) {
+php::MethodCallCacheSlot &typephp_get_method_call_cache(MethodCallCacheId cache_id) noexcept {
     return php_request_cache->method_call_cache_map[static_cast<uint32_t>(cache_id)];
 }
 
-php::FunctionCallCacheSlot &typephp_get_function_call_cache(FunctionCallCacheId cache_id) {
+php::FunctionCallCacheSlot &typephp_get_function_call_cache(FunctionCallCacheId cache_id) noexcept {
     return php_request_cache->function_call_cache_map[static_cast<uint32_t>(cache_id)];
 }
 CODE;
@@ -1302,7 +1302,7 @@ CODE;
             }
             $code .= '};' . PHP_EOL . PHP_EOL;
             $code .= 'ZEND_ATTRIBUTE_CONST ' . Type::STR . ' &'
-                . self::LITERAL_STRING_GETTER . '(uint32_t index) {' . PHP_EOL;
+                . self::LITERAL_STRING_GETTER . '(uint32_t index) noexcept {' . PHP_EOL;
             $code .= $this->getIndent() . 'return ' . self::LITERAL_STRINGS . '[index];' . PHP_EOL;
             $code .= '}' . PHP_EOL . PHP_EOL;
         } else {


### PR DESCRIPTION
Generated literal-string and request-cache slot accessors only index existing
arrays and return references, but their cross-translation-unit declarations
currently allow C++ exceptions. Callers consequently retain exception cleanup
metadata for calls that cannot throw.

Add `noexcept` consistently to declarations and definitions of `get_str`,
`get_property_cache`, `typephp_get_method_call_cache`, and
`typephp_get_function_call_cache`. Keep resolving lookups potentially throwing.
Add coverage for the generated declarations and definitions.

Validation: 103 focused PHPUnit tests / 616 assertions, 51 compiled dungeon
behavior assertions matching PHP, and an exception probe covering finally,
previous exception identity, rethrow identity, and invalid throwable handling.
The 11 PHPUnit deprecations also occur on the baseline. Multi-file AOT builds
and output checks pass on Linux ARM64, GCC, PHP 8.5.10 ZTS, PHPX 4b3a472.

In an unchanged exception-heavy dungeon replay, two subsequent alternating
baseline/candidate batches reduce median elapsed time by 4.1% and 4.8%.
Each batch uses one warmup pair and five measured pairs of 20,000 games.
The dungeon translation unit's exception table shrinks from 2,848 to 2,604
bytes; text grows by 196 bytes and unwind-frame data grows by 16 bytes.
These measurements are workload/platform specific, not a general PHP speedup.

Normal-path short measurements vary in both directions. An extended run of
100,000 games per sample is effectively flat: baseline median 2.482272 seconds,
candidate 2.473237 seconds (-0.36%), with overlapping sample ranges. No
normal-path speedup is claimed. An earlier batch under heavy host CPU contention
is retained as inconclusive evidence, not used to substantiate the performance
claim. Windows/macOS and other compiler configurations have not been tested for
this change.
