### PR TITLE
Keep boolean condition snapshots in native storage

### DIFF
--- a/phpunit/code/native-condition-temporaries.php
+++ b/phpunit/code/native-condition-temporaries.php
@@ -1,0 +1,25 @@
+<?php
+
+function nativeCondition(array $values): int
+{
+    if ($values[0] === 1) {
+        return 1;
+    }
+    if ($values[0] === 2 || $values[1] === 3) {
+        return 2;
+    }
+    return 0;
+}
+
+function dynamicConditionValue(mixed $value): mixed
+{
+    return $value;
+}
+
+function dynamicCondition(array $values): bool
+{
+    if (dynamicConditionValue($values[0])) {
+        return true;
+    }
+    return false;
+}

--- a/phpunit/src/NativeConditionTemporaryTest.php
+++ b/phpunit/src/NativeConditionTemporaryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use TypePhp\CompilerTest;
+
+final class NativeConditionTemporaryTest extends BaseTest
+{
+    public function testBooleanConditionsWithOperandCleanupRemainUnboxed(): void
+    {
+        global $translator;
+        $compiler = CompilerTest::create(TYPEPHP_ROOT_PATH);
+        $translator = $compiler;
+        $source = TYPEPHP_ROOT_PATH . '/phpunit/code/native-condition-temporaries.php';
+        $compiler->addFiles([$source]);
+        $compiler->prepareFile($source);
+        $code = file_get_contents($compiler->convertFile($source));
+
+        preg_match_all('/(tmp_var_\d+) = php::toBool\(php::same\(/', $code, $matches);
+        self::assertCount(2, $matches[1]);
+        foreach ($matches[1] as $temporary) {
+            self::assertStringContainsString('php::Bool ' . $temporary . ' = 0;', $code);
+        }
+
+        $dynamicBody = explode('php::Bool php_dynamiccondition(', $code, 2)[1];
+        $dynamicBody = explode("\n}", $dynamicBody, 2)[0];
+        self::assertStringContainsString('php::Var tmp_var_1;', $dynamicBody);
+        self::assertStringContainsString('tmp_var_1 = php_dynamicconditionvalue(', $dynamicBody);
+    }
+}

--- a/src/CompilerBase.php
+++ b/src/CompilerBase.php
@@ -1984,7 +1984,13 @@ class CompilerBase implements PropertyAccessContext
         $code = '';
         $code .= $this->formatCapturedStmtLines($beforeStmts);
         if ($afterStmts) {
-            $tmpVar = $this->addTmpVar(Type::VAR);
+            // Boolean results own no zval resources and can survive operand
+            // cleanup in native storage without changing evaluation order.
+            $type = $this->detectTypeOfExpr($cond) === Type::BOOL ? Type::BOOL : Type::VAR;
+            $tmpVar = $this->addTmpVar($type);
+            if ($type === Type::BOOL) {
+                $condExpr = $this->convertBoolExpr($condExpr);
+            }
             $code .= $this->getIndent() . $tmpVar . ' = ' . $condExpr . ';' . PHP_EOL;
             $code .= $this->formatCapturedStmtLines($afterStmts);
             $condExpr = $tmpVar;

--- a/src/CompilerBase.php
+++ b/src/CompilerBase.php
@@ -4507,6 +4507,9 @@ class CompilerBase implements PropertyAccessContext
 
         $this->context = new FunctionContext();
         $this->context->arguments = $oriCtx->localVars;
+        // Outer locals are captured arguments. New initializer temporaries
+        // must not reuse their names and inherit an incompatible scalar type.
+        $this->context->tmpVarIndex = $oriCtx->tmpVarIndex;
 
         $code = '([&](){' . PHP_EOL;
         $body = $this->getIndent() . $varName . ' = ' . $this->parseExpr($var->default) . ';';

--- a/src/Parser/BinaryOpTrait.php
+++ b/src/Parser/BinaryOpTrait.php
@@ -1275,7 +1275,11 @@ trait BinaryOpTrait
         $this->indentLevel++;
         $code .= $this->formatCapturedStmtLines($rightBeforeStmts);
         if ($rightAfterStmts) {
-            $rightTmpVar = $this->addTmpVar(Type::VAR);
+            $type = $this->detectTypeOfExpr($right) === Type::BOOL ? Type::BOOL : Type::VAR;
+            $rightTmpVar = $this->addTmpVar($type);
+            if ($type === Type::BOOL) {
+                $rightExpr = $this->convertBoolExpr($rightExpr);
+            }
             $code .= $this->getIndent() . $rightTmpVar . ' = ' . $rightExpr . ';' . PHP_EOL;
             $code .= $this->formatCapturedStmtLines($rightAfterStmts);
             $rightExpr = $rightTmpVar;

--- a/tests/compiler/optimizations/native-condition-static-initializer.phpt
+++ b/tests/compiler/optimizations/native-condition-static-initializer.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Static initializer temporaries do not reuse outer native condition snapshots
+--FILE--
+<?php
+function conditionBeforeStatic(array $args): void {
+    if ($args === []) { return; }
+    static $table = [[[7, 'value']]];
+    echo $table[0][0][1], "\n";
+}
+function main(): void { conditionBeforeStatic([1]); conditionBeforeStatic([2]); }
+--EXPECT--
+value
+value

--- a/tests/compiler/optimizations/native-condition-static-initializer.phpt
+++ b/tests/compiler/optimizations/native-condition-static-initializer.phpt
@@ -8,6 +8,7 @@ function conditionBeforeStatic(array $args): void {
     echo $table[0][0][1], "\n";
 }
 function main(): void { conditionBeforeStatic([1]); conditionBeforeStatic([2]); }
+?>
 --EXPECT--
 value
 value


### PR DESCRIPTION
Conditions with operand cleanup must save their result before releasing the
operands. Both branch conditions and short-circuit right operands currently
box that saved result in `php::Var`, even when its type is known to be boolean.

Use `php::Bool` only for inferred boolean snapshots, normalizing the emitted
value through `php::toBool` before the existing cleanup. Keep other result
types boxed. Evaluation order, short-circuit behavior, and operand cleanup
remain intact. Add code-generation coverage for the optimized boolean cases
and a mixed-return call that must retain the Variant fallback.

Static initializer lambdas start their temporary counter after captured outer
locals, preventing initializer array temporaries from accidentally reusing an
outer boolean snapshot. A PHPT covers nested static arrays after a condition.
The complete 135-file compiler self-build, its --version invocation, and
compiling/running the regression with the resulting compiler all pass locally.

Validation: focused codegen/evaluation-order tests pass; separately compiled
existing short-circuit, condition-side-effect, and weak-reference lifetime
cases match expected stdout with empty stderr. The 51-assertion dungeon suite
matches PHP. Independent review found no remaining issue.

On Linux ARM64, GCC O2, PHP 8.5.10 ZTS and PHPX 4b3a472, two final-source
alternating baseline/candidate measurement batches reduce normal-only elapsed
time by 5.18% and 4.73% (100,000 games/sample), and exception-heavy elapsed
time by 6.26% and 3.75% (20,000 games/sample). Each batch uses one warmup pair
and five measured pairs; output is checked every time. The game sources are
unchanged. The command function replaces six Variant temporaries with Bool.

This PR is based directly on master and does not include or require #105.
The reported performance experiment included #105 (`10629f60`) in both binaries;
neither binary included #104. These percentages have not been remeasured
without #105.
Results are workload/platform-specific. Other platforms and Python
interoperability have not been runtime-tested for this change.
